### PR TITLE
Mixed CPU/GPU fleets: per-host install modes + tracking (CLI 1.8.0 / Collection 1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to `r1setup` and the `ratio1.multi_node_launcher`
+Ansible collection are recorded here. The CLI version (`scripts/ver.py`)
+and the collection version (`mnl_factory/galaxy.yml`) track separate
+lineages and may bump independently.
+
+## CLI 1.8.0 / Collection 1.4.0 — 2026-04-19
+
+Mixed CPU/GPU fleets with per-host install tracking.
+
+### Added
+
+- **Three install modes**, chosen from the deployment menu:
+  - **Install CPU Nodes** — deploys the CPU image
+    (`ratio1/edge_node:{env}`), skips all NVIDIA setup.
+  - **Install GPU Nodes (r1setup manages drivers)** — runs the
+    `nvidia_gpu` role to install NVIDIA drivers + the NVIDIA Container
+    Toolkit, then deploys the GPU image (`ratio1/edge_node_gpu:{env}`).
+  - **Install GPU Nodes (user-managed drivers)** — skips the
+    `nvidia_gpu` role entirely, runs a preflight `nvidia-smi` check
+    on the target host, and deploys the GPU image. r1setup does NOT
+    touch NVIDIA packages on the host in this mode.
+- **Per-host install tracking** persisted in `hosts.yml` for each host:
+  last successful variant, driver owner (r1setup / user / n/a),
+  timestamp, collection version; plus last-attempted variant, owner,
+  timestamp, and result (success / failed). Visible in the
+  host-selection menu as `GPU (r1) • 2026-03-12` / `CPU • 2026-02-01`
+  / `—  • never`, with a "last attempt" column highlighting failures
+  or divergence.
+- **Image Summary** block after each successful deploy reads the new
+  fetched metadata JSON and lists the image variant + URL per host.
+- **Mode-specific failure hints** for GPU deploys that had failed hosts:
+  Mode 2 points at the driver-cleanup rescue and CPU recovery path;
+  Mode 3 explicitly states that r1setup did not touch drivers and asks
+  the user to repair or re-run with driver management enabled.
+
+### Changed
+
+- GPU-install failures no longer silently fall back to CPU. Failed
+  hosts are listed for retry in the final report; surviving hosts
+  continue to deploy normally.
+- Docker image name is now variant-aware via new group_vars
+  `mnl_docker_image_name_cpu` / `mnl_docker_image_name_gpu`. CLI
+  passes the variant via `mnl_image_variant_cli`; host_vars can pin
+  `mnl_image_variant: gpu|cpu` to override the CLI choice on a per-host
+  basis. User overrides of `mnl_docker_image_url` via CUSTOMIZABLE_VARS
+  still win (Ansible extra-vars beat group_vars).
+- `site.yml` and `prepare_machine.yml` converted to `tasks:` structure
+  with `block/rescue` around the `nvidia_gpu` role. Mode-2 failures
+  run `apt autoremove nvidia*` cleanup and then re-raise (no silent
+  fallback). Mode 3 skips the block entirely — user-managed drivers
+  are never touched.
+- Per-host metadata is now fetched back to the controller at
+  `/tmp/r1setup-fetched/{host}.json` so the CLI reads structured per-host
+  data instead of parsing Ansible stdout.
+- Deployment menu labels: "Deploy with GPU" → **"Install GPU Nodes"**;
+  "Deploy CPU Only" → **"Install CPU Nodes"**.
+
+### Removed
+
+- Fleet-level `last_deployment_type` config field (it lied on mixed
+  fleets). Stale values are popped from metadata on load. Replaced by a
+  per-host variant rollup `GPU: N, CPU: M, Never: K` derived from
+  `r1setup_last_install_variant`.
+
+### Migration
+
+- Old inventories gain the eight new per-host install-tracking fields
+  as `None` on first load under 1.8.0; the menu renders them as
+  `— • never` until the first successful install populates them.
+- `last_deployment_type` is removed on load; callers should derive the
+  variant summary from per-host state.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The modular test package lives in [mnl_factory/scripts/tests](mnl_factory/script
   - triggered by `mnl_factory/scripts/ver.py`
 - Ansible Galaxy publish workflow: [.github/workflows/publish-ansible-galaxy.yml](.github/workflows/publish-ansible-galaxy.yml)
   - triggered by `mnl_factory/galaxy.yml`
+- Release notes: [CHANGELOG.md](CHANGELOG.md)
 
 ### Citations
 

--- a/mnl_factory/galaxy.yml
+++ b/mnl_factory/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: "ratio1"
 name: "multi_node_launcher"
-version: "1.3.35"
+version: "1.4.0"
 readme: "README.md"
 authors:
   - Andrei Damian <andrei.damian@me.com>

--- a/mnl_factory/group_vars/mnl.yml
+++ b/mnl_factory/group_vars/mnl.yml
@@ -21,7 +21,13 @@ mnl_docker_persistent_folder: "/edge_node/_local_cache"
 
 mnl_cr_server: "docker.io"
 mnl_cr_user: "ratio1"
-mnl_docker_image_name: "edge_node"
+mnl_docker_image_name_cpu: "edge_node"
+mnl_docker_image_name_gpu: "edge_node_gpu"
+
+# CLI passes mnl_image_variant_cli as an extra-var. Host_vars / group_vars can
+# pin mnl_image_variant directly (host_vars > group_vars > cli default).
+mnl_image_variant: "{{ mnl_image_variant_cli | default('cpu') }}"
+mnl_docker_image_name: "{{ mnl_docker_image_name_gpu if mnl_image_variant == 'gpu' else mnl_docker_image_name_cpu }}"
 mnl_docker_image_url: "{{ mnl_cr_user }}/{{ mnl_docker_image_name }}:{{ mnl_app_env }}"
 
 mnl_docker_pull_limit: 5

--- a/mnl_factory/playbooks/prepare_machine.yml
+++ b/mnl_factory/playbooks/prepare_machine.yml
@@ -9,8 +9,31 @@
     - ../group_vars/vault.yml
     - ../group_vars/mnl.yml
     - ../group_vars/variables.yml
-  roles:
-    - role: "{{ playbook_dir }}/../roles/prerequisites"
-    - role: "{{ playbook_dir }}/../roles/docker"
-    - role: "{{ playbook_dir }}/../roles/nvidia_gpu"
+  tasks:
+    - name: Run prerequisites role
+      import_role:
+        name: prerequisites
+
+    - name: Run docker role
+      import_role:
+        name: docker
+
+    # GPU driver install (Mode 2). Wrapped in block/rescue so a failure
+    # cleans up partial NVIDIA packages and then re-raises — no silent
+    # fallback to CPU. Mode 3 (skip_gpu=true) skips the whole block, so
+    # we never touch user-managed drivers.
+    - name: GPU driver install (with cleanup on failure)
+      block:
+        - name: Include nvidia_gpu role
+          include_role:
+            name: nvidia_gpu
+      rescue:
+        - name: Cleanup partial NVIDIA install on failure (r1setup-managed drivers only)
+          shell: "apt autoremove nvidia* --purge -y"
+          become: true
+          ignore_errors: true
+          when: ansible_os_family == "Debian"
+        - name: Re-raise GPU install failure (no fallback)
+          fail:
+            msg: "GPU install failed on {{ inventory_hostname }} — partial driver state cleaned up. See earlier task output."
       when: skip_gpu is not defined or not skip_gpu

--- a/mnl_factory/playbooks/probe_install_state.yml
+++ b/mnl_factory/playbooks/probe_install_state.yml
@@ -1,0 +1,84 @@
+---
+# Probe a host's current install state and fetch a small JSON summary back
+# to the controller so the CLI can back-populate the per-host install
+# tracking fields introduced in 1.8.0 for fleets that were first deployed
+# under 1.7.x or earlier. Read-only: no packages installed, no config
+# changes on the target host.
+- name: Probe install state for migration
+  hosts: gpu_nodes
+  become: true
+  vars:
+    ansible_roles_path: "{{ playbook_dir }}/../roles"
+  vars_files:
+    - ../group_vars/all.yml
+    - ../group_vars/vault.yml
+    - ../group_vars/mnl.yml
+    - ../group_vars/variables.yml
+  tasks:
+    - name: Read deployed image from docker inspect
+      ansible.builtin.shell: |
+        docker inspect {{ mnl_docker_container_name }} --format '{{ "{{" }}.Config.Image{{ "}}" }}' 2>/dev/null || true
+      register: probe_docker_image
+      changed_when: false
+      failed_when: false
+
+    - name: Check for --gpus in the rendered systemd unit
+      ansible.builtin.shell: |
+        grep -c -- '--gpus' /etc/systemd/system/{{ edge_node_service_name }}.service 2>/dev/null || echo 0
+      register: probe_gpu_flag
+      changed_when: false
+      failed_when: false
+
+    - name: Check for NVIDIA Container Toolkit (implies r1setup-managed drivers)
+      ansible.builtin.shell: |
+        dpkg -s nvidia-container-toolkit >/dev/null 2>&1 && echo yes || echo no
+      register: probe_nvct
+      changed_when: false
+      failed_when: false
+
+    - name: Check nvidia-smi availability
+      ansible.builtin.shell: |
+        nvidia-smi >/dev/null 2>&1 && echo yes || echo no
+      register: probe_nvidia_smi
+      changed_when: false
+      failed_when: false
+
+    - name: Read pre-existing r1setup metadata (last_applied_at) if any
+      ansible.builtin.slurp:
+        src: "{{ mnl_r1setup_metadata_host_path }}"
+      register: probe_metadata_slurp
+      failed_when: false
+      ignore_errors: true
+
+    - name: Compose probe summary
+      ansible.builtin.set_fact:
+        r1setup_probe_summary:
+          docker_image: "{{ probe_docker_image.stdout | default('') | trim }}"
+          systemd_has_gpu_flag: "{{ (probe_gpu_flag.stdout | default('0') | trim | int) > 0 }}"
+          nvidia_container_toolkit: "{{ (probe_nvct.stdout | default('no') | trim) == 'yes' }}"
+          nvidia_smi_works: "{{ (probe_nvidia_smi.stdout | default('no') | trim) == 'yes' }}"
+          prior_metadata: >-
+            {{
+              (probe_metadata_slurp.content | b64decode | from_json)
+              if (probe_metadata_slurp is defined
+                  and probe_metadata_slurp.content is defined
+                  and probe_metadata_slurp.content | length > 0)
+              else {}
+            }}
+
+    - name: Write probe summary to a controller-fetchable path
+      ansible.builtin.copy:
+        dest: "/tmp/r1setup-probe-{{ inventory_hostname }}.json"
+        content: "{{ r1setup_probe_summary | to_nice_json }}"
+        mode: '0644'
+
+    - name: Fetch probe summary back to the controller
+      ansible.builtin.fetch:
+        src: "/tmp/r1setup-probe-{{ inventory_hostname }}.json"
+        dest: "{{ r1setup_fetched_metadata_dir | default('/tmp/r1setup-fetched') }}/probe-{{ inventory_hostname }}.json"
+        flat: true
+
+    - name: Cleanup probe summary on the target
+      ansible.builtin.file:
+        path: "/tmp/r1setup-probe-{{ inventory_hostname }}.json"
+        state: absent

--- a/mnl_factory/playbooks/probe_install_state.yml
+++ b/mnl_factory/playbooks/probe_install_state.yml
@@ -22,6 +22,32 @@
       changed_when: false
       failed_when: false
 
+    # Fallback: extract the image URL from the rendered systemd unit.
+    # edge_node.service includes a literal "docker pull <url>" line that the
+    # template rendered at deploy time, so even if the container was removed
+    # or renamed we still have evidence of which image was last deployed.
+    - name: Extract image URL from systemd unit (fallback)
+      ansible.builtin.shell: |
+        awk '/docker pull/ {for (i=1;i<=NF;i++) if ($i ~ /\//) {print $i; exit}}' \
+          /etc/systemd/system/{{ edge_node_service_name }}.service 2>/dev/null \
+          || true
+      register: probe_unit_image
+      changed_when: false
+      failed_when: false
+
+    # Second fallback: if our expected container name isn't present, enumerate
+    # every ratio1/edge_node* container on the host. Handles very old deploys
+    # that used a different container name.
+    - name: List any ratio1 edge_node containers on the host (fallback)
+      ansible.builtin.shell: |
+        docker ps -a --format '{{ "{{" }}.Image{{ "}}" }}' 2>/dev/null \
+          | grep -E '(^|/)edge_node(_gpu)?(:|$)' \
+          | head -1 \
+          || true
+      register: probe_any_image
+      changed_when: false
+      failed_when: false
+
     - name: Check for --gpus in the rendered systemd unit
       ansible.builtin.shell: |
         grep -c -- '--gpus' /etc/systemd/system/{{ edge_node_service_name }}.service 2>/dev/null || echo 0
@@ -53,7 +79,13 @@
     - name: Compose probe summary
       ansible.builtin.set_fact:
         r1setup_probe_summary:
-          docker_image: "{{ probe_docker_image.stdout | default('') | trim }}"
+          # Primary, then systemd-unit fallback, then any-ratio1-container fallback.
+          docker_image: >-
+            {{
+              (probe_docker_image.stdout | default('') | trim)
+              or (probe_unit_image.stdout | default('') | trim)
+              or (probe_any_image.stdout | default('') | trim)
+            }}
           systemd_has_gpu_flag: "{{ (probe_gpu_flag.stdout | default('0') | trim | int) > 0 }}"
           nvidia_container_toolkit: "{{ (probe_nvct.stdout | default('no') | trim) == 'yes' }}"
           nvidia_smi_works: "{{ (probe_nvidia_smi.stdout | default('no') | trim) == 'yes' }}"

--- a/mnl_factory/playbooks/site.yml
+++ b/mnl_factory/playbooks/site.yml
@@ -9,10 +9,35 @@
     - ../group_vars/vault.yml
     - ../group_vars/mnl.yml
     - ../group_vars/variables.yml
-  roles:
-    - role: "{{ playbook_dir }}/../roles/prerequisites"
-    - role: "{{ playbook_dir }}/../roles/docker"
-    - role: "{{ playbook_dir }}/../roles/nvidia_gpu"
-      when: skip_gpu is not defined or not skip_gpu
-    - role: "{{ playbook_dir }}/../roles/setup"
+  tasks:
+    - name: Run prerequisites role
+      import_role:
+        name: prerequisites
 
+    - name: Run docker role
+      import_role:
+        name: docker
+
+    # GPU driver install (Mode 2). Wrapped in block/rescue so a failure
+    # cleans up partial NVIDIA packages and then re-raises — no silent
+    # fallback to CPU. Mode 3 (skip_gpu=true) skips the whole block, so
+    # we never touch user-managed drivers.
+    - name: GPU driver install (with cleanup on failure)
+      block:
+        - name: Include nvidia_gpu role
+          include_role:
+            name: nvidia_gpu
+      rescue:
+        - name: Cleanup partial NVIDIA install on failure (r1setup-managed drivers only)
+          shell: "apt autoremove nvidia* --purge -y"
+          become: true
+          ignore_errors: true
+          when: ansible_os_family == "Debian"
+        - name: Re-raise GPU install failure (no fallback)
+          fail:
+            msg: "GPU install failed on {{ inventory_hostname }} — partial driver state cleaned up. See earlier task output."
+      when: skip_gpu is not defined or not skip_gpu
+
+    - name: Run setup role
+      import_role:
+        name: setup

--- a/mnl_factory/roles/nvidia_gpu/tasks/main.yml
+++ b/mnl_factory/roles/nvidia_gpu/tasks/main.yml
@@ -19,8 +19,22 @@
 - name: Skip message if no NVIDIA GPU found
   debug:
     msg: "No NVIDIA GPU detected. Skipping driver installation."
-  when: 
+  when:
     - (skip_gpu is not defined or not skip_gpu)
+    - nvidia_gpu_check.rc != 0
+
+# Fail loudly when the GPU variant was requested but no NVIDIA GPU is present.
+# No silent fallback to CPU — the user either picks 'Install CPU Nodes' or
+# fixes the hardware before retrying.
+- name: Fail if GPU variant requested but no NVIDIA GPU detected
+  fail:
+    msg: |
+      GPU install requested on {{ inventory_hostname }} but no NVIDIA GPU
+      was detected. Re-run this host via 'Install CPU Nodes', or fix the
+      NVIDIA hardware/drivers before retrying GPU install.
+  when:
+    - (skip_gpu is not defined or not skip_gpu)
+    - mnl_image_variant | default('cpu') == 'gpu'
     - nvidia_gpu_check.rc != 0
 
 # GPU Installation and Setup - Only proceed if GPU is detected

--- a/mnl_factory/roles/setup/tasks/main.yml
+++ b/mnl_factory/roles/setup/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+# Mode-3 preflight: user said they manage GPU drivers (skip_gpu=true) but
+# asked for the GPU image. Verify nvidia-smi works here, BEFORE we pull
+# anything, so a broken user-managed setup fails loudly without us touching
+# their drivers.
+- name: Preflight nvidia-smi check (user-managed GPU drivers)
+  command: nvidia-smi
+  register: r1setup_user_nvidia_smi
+  changed_when: false
+  failed_when: r1setup_user_nvidia_smi.rc != 0
+  when:
+    - mnl_image_variant | default('cpu') == 'gpu'
+    - skip_gpu | default(false)
+
 - name: Log into Docker registry
   docker_login:
     registry: "{{ docker_registry }}"

--- a/mnl_factory/roles/setup/tasks/render_edge_node_definition.yml
+++ b/mnl_factory/roles/setup/tasks/render_edge_node_definition.yml
@@ -36,6 +36,15 @@
     mode: '0644'
     force: true
 
+# Fetch the rendered metadata file back to the controller so the CLI can
+# read per-host variant / driver_owner / image_url reliably (rather than
+# parsing Ansible stdout, which varies by callback plugin).
+- name: Fetch r1setup metadata for CLI report
+  ansible.builtin.fetch:
+    src: "{{ mnl_r1setup_metadata_host_path }}"
+    dest: "{{ r1setup_fetched_metadata_dir | default('/tmp/r1setup-fetched') }}/{{ inventory_hostname }}.json"
+    flat: true
+
 - name: Create helper registry directory
   ansible.builtin.file:
     path: "{{ r1setup_helper_registry_dir }}"

--- a/mnl_factory/roles/setup/templates/edge_node.service.j2
+++ b/mnl_factory/roles/setup/templates/edge_node.service.j2
@@ -20,7 +20,7 @@ ExecStartPre=-/usr/bin/docker pull {{ mnl_docker_image_url }}
 
 # Start the container
 ExecStart=/bin/sh -c '/usr/bin/docker run \
-    {% if (skip_gpu is not defined or not skip_gpu) and nvidia_smi_check1 is defined and nvidia_smi_check1.rc is defined and nvidia_smi_check1.rc == 0 %}{{ mnl_docker_gpus }} {% endif %} \
+    {% if mnl_image_variant | default('cpu') == 'gpu' %}{{ mnl_docker_gpus }} {% endif %} \
     {{ mnl_port_forward | default('') }} \
     --rm \
     --privileged \

--- a/mnl_factory/roles/setup/templates/r1setup-metadata.json.j2
+++ b/mnl_factory/roles/setup/templates/r1setup-metadata.json.j2
@@ -7,5 +7,9 @@
   "app_env": {{ mnl_app_env | default('unknown', true) | to_json }},
   "node_name": {{ inventory_hostname | to_json }},
   "last_applied_action": {{ r1setup_last_applied_action_effective | default('unknown', true) | to_json }},
-  "last_applied_at": {{ ansible_date_time.iso8601 | default('unknown', true) | to_json }}
+  "last_applied_at": {{ ansible_date_time.iso8601 | default('unknown', true) | to_json }},
+  "image_variant": {{ mnl_image_variant | default('cpu') | to_json }},
+  "image_url": {{ mnl_docker_image_url | to_json }},
+  "driver_owner": {{ ('r1setup' if (mnl_image_variant | default('cpu') == 'gpu' and not (skip_gpu | default(false))) else ('user' if (mnl_image_variant | default('cpu') == 'gpu' and (skip_gpu | default(false))) else 'n/a')) | to_json }},
+  "applied_at": {{ ansible_date_time.iso8601 | default('unknown', true) | to_json }}
 }

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -5417,22 +5417,63 @@ class DeploymentService:
         self.app.wait_for_enter()
 
     def deploy_full(self) -> None:
-        """Deploy full setup (Docker + NVIDIA + GPU)"""
+        """Install GPU Nodes — deploys the GPU edge_node image.
+
+        Sub-prompts whether r1setup should install/manage the NVIDIA drivers
+        (Mode 2) or whether the user has already set them up themselves
+        (Mode 3). Mode 3 skips the nvidia_gpu role entirely and runs a
+        preflight nvidia-smi check before the Docker pull.
+        """
+        self.app.print_header("Install GPU Nodes")
+        self.app.print_colored(
+            "\nThis deploys the GPU image (ratio1/edge_node_gpu:{env}) on the hosts you select.\n"
+            "GPU installs never silently fall back to CPU — if anything goes wrong, the affected\n"
+            "hosts fail loudly and are listed for retry.",
+            'cyan',
+        )
+        self.app.print_colored(
+            "\nShould r1setup install and manage the NVIDIA drivers on the selected hosts?",
+            'yellow',
+            bold=True,
+        )
+        self.app.print_colored(
+            "   Y = r1setup installs drivers + NVIDIA Container Toolkit (default)",
+            'white',
+        )
+        self.app.print_colored(
+            "   N = drivers are already installed by you; r1setup only verifies nvidia-smi and deploys the image",
+            'white',
+        )
+        answer = self.app.get_input(
+            "Install/manage NVIDIA drivers? (Y/n)", "Y"
+        ).strip().lower()
+        manage_drivers = answer not in ('n', 'no')
+
+        if manage_drivers:
+            description = "Docker + NVIDIA drivers + GPU image deploy"
+            last_applied_action = "deploy_gpu_managed"
+        else:
+            description = "GPU image deploy (user-managed NVIDIA drivers)"
+            last_applied_action = "deploy_gpu_user_drivers"
+
         self._deploy_setup(
             "site.yml",
-            "Full Deployment",
-            "Docker + NVIDIA drivers + GPU setup",
-            last_applied_action="deploy_full",
+            "Install GPU Nodes",
+            description,
+            variant="gpu",
+            manage_drivers=manage_drivers,
+            last_applied_action=last_applied_action,
         )
 
     def deploy_docker_only(self) -> None:
-        """Deploy Docker only"""
+        """Install CPU Nodes — deploys the CPU edge_node image, skips all GPU setup."""
         self._deploy_setup(
             "site.yml",
-            "Docker-Only Deployment",
-            "Docker without GPU setup",
-            extra_vars={"skip_gpu": True},
-            last_applied_action="deploy_docker_only",
+            "Install CPU Nodes",
+            "Docker only (CPU image deploy)",
+            variant="cpu",
+            manage_drivers=False,
+            last_applied_action="deploy_cpu",
         )
 
     def delete_edge_node(self) -> None:
@@ -5544,15 +5585,56 @@ class DeploymentService:
 
         self.app.wait_for_enter()
 
+    @staticmethod
+    def _build_install_extra_vars(
+        variant: str,
+        manage_drivers: bool,
+    ) -> Dict[str, Any]:
+        """Validate the (variant, manage_drivers) pair and return the
+        extra-vars dict that the Ansible playbook expects.
+
+        Legal combinations:
+          - ('cpu', False) -> Mode 1 (CPU install)
+          - ('gpu', True)  -> Mode 2 (GPU install, r1setup manages drivers)
+          - ('gpu', False) -> Mode 3 (GPU image only, user-managed drivers)
+
+        Rejects 'cpu' + manage_drivers=True: installing drivers for a CPU
+        deploy makes no sense and almost always signals a refactor bug.
+        """
+        if variant not in ('cpu', 'gpu'):
+            raise ValueError(f"Invalid variant {variant!r}; expected 'cpu' or 'gpu'")
+        if variant == 'cpu' and manage_drivers:
+            raise ValueError(
+                "Illegal install mode: variant='cpu' with manage_drivers=True. "
+                "CPU install does not install NVIDIA drivers."
+            )
+
+        extra_vars: Dict[str, Any] = {"mnl_image_variant_cli": variant}
+        # skip_gpu is true for Mode 1 and Mode 3 — in both, we don't run
+        # the nvidia_gpu role. Only Mode 2 (manage_drivers=True) runs it.
+        if not manage_drivers:
+            extra_vars["skip_gpu"] = True
+        return extra_vars
+
     def _deploy_setup(
         self,
         playbook: str,
         title: str,
         description: str,
-        extra_vars: Optional[Dict[str, Any]] = None,
+        variant: str,
+        manage_drivers: bool,
         last_applied_action: str = "deploy",
     ) -> None:
-        """Common deployment logic with host selection"""
+        """Common deployment logic with host selection.
+
+        variant: 'cpu' or 'gpu' — selects the image variant.
+        manage_drivers: when True (Mode 2), r1setup runs the nvidia_gpu role
+            to install/manage drivers. When False for variant='gpu' (Mode 3),
+            the nvidia_gpu role is skipped and a preflight nvidia-smi check
+            runs instead. For variant='cpu', always False.
+        """
+        extra_vars = self._build_install_extra_vars(variant, manage_drivers)
+
         if not self.app.check_hosts_config():
             self.app.print_colored("No nodes configured! Please configure nodes first.", 'red')
             self.app.wait_for_enter()
@@ -5732,8 +5814,9 @@ class DeploymentService:
 
         if success:
             self.app.print_colored(f"\n✅ Deployment succeeded on {len(successful_instance_hosts)} node(s)", 'green')
-            # Update deployment metadata after successful deployment
-            deployment_type = "full" if "NVIDIA" in description else "docker_only"
+            # Update deployment metadata after successful deployment.
+            # deployment_type derives from variant (not a description string sniff).
+            deployment_type = "full" if variant == "gpu" else "docker_only"
             self._update_deployment_metadata(deployment_type)
             self.app.record_service_file_version(successful_instance_hosts)
 
@@ -11280,8 +11363,8 @@ PY"""
 
             self.print_colored("Deployment Menu", 'cyan', bold=True)
             print()
-            self.print_colored("  1) Deploy with GPU        - Deploy full Edge Node with GPU support")
-            self.print_colored("  2) Deploy CPU Only        - Deploy Edge Node without GPU capabilities")
+            self.print_colored("  1) Install GPU Nodes      - Deploy Edge Node with GPU image (ratio1/edge_node_gpu)")
+            self.print_colored("  2) Install CPU Nodes      - Deploy Edge Node with CPU image (ratio1/edge_node)")
             self.print_colored("  3) Prepare Machines       - Prepare registered machines without deploying nodes")
             self.print_colored("  4) Plan Migration        - Build and save a migration plan without executing it")
             self.print_colored("  5) Execute Migration    - Run the saved migration plan")

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -72,7 +72,10 @@ DEBUG = False  # Set to True to enable debug output, or use --debug flag
 
 # Version information
 UPDATE_CHECK_URL = "https://raw.githubusercontent.com/Ratio1/r1setup/refs/heads/main/mnl_factory/scripts/ver.py"
-DOWNLOAD_BASE_URL = "https://github.com/Ratio1/multi_node_launcher/releases/download"
+# Release assets are published to this repo by .github/workflows/release.yml.
+# (Previously pointed at Ratio1/multi_node_launcher which 404s; the raw-main
+# fallback in _perform_update masked the bug. Fixed in 1.8.0.)
+DOWNLOAD_BASE_URL = "https://github.com/Ratio1/r1setup/releases/download"
 
 # Whitelist of service template variables that can be overridden via Advanced → Customize Service
 CUSTOMIZABLE_VARS = {
@@ -1172,6 +1175,9 @@ class ConfigurationManager:
             'last_deployed_network': None,
             'deployment_status': 'never_deployed',
             'last_deleted_date': None,
+            'last_written_cli_version': None,
+            'last_written_collection_version': None,
+            'last_written_at': None,
         }
 
     def _load_active_config(self) -> None:
@@ -1188,6 +1194,9 @@ class ConfigurationManager:
             'last_deployed_network': None,
             'deployment_status': 'never_deployed',
             'last_deleted_date': None,
+            'last_written_cli_version': None,
+            'last_written_collection_version': None,
+            'last_written_at': None,
         }
 
         if self.app.active_config_file.exists():
@@ -2739,6 +2748,13 @@ class ConfigurationManager:
         metadata['environment'] = environment
         metadata['nodes_count'] = nodes_count
         metadata['config_schema_version'] = CONFIG_SCHEMA_VERSION
+        # Version stamping: record the CLI + collection versions that wrote
+        # this config, plus the write timestamp, so post-mortems can reason
+        # about what tooling produced it. Added in 1.8.0; older configs gain
+        # these keys on first save under 1.8.0.
+        metadata['last_written_cli_version'] = CLI_VERSION
+        metadata['last_written_collection_version'] = self.get_collection_version()
+        metadata['last_written_at'] = datetime.now().isoformat()
         fleet_for_save = self._merge_fleet_state(self.fleet_state or metadata.get('fleet_state'), self.app.inventory)
         metadata['machines_count'] = len(fleet_for_save.get('fleet', {}).get('machines', {}))
         metadata['fleet_state'] = fleet_for_save

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -14362,6 +14362,58 @@ PY"""
         except ImportError:
             return self._fallback_select_hosts(hosts, operation_name, initial_selection, preselection_label)
 
+    @staticmethod
+    def _format_install_history(host_config: Dict[str, Any], include_attempt: bool = True) -> str:
+        """Return a compact one-line summary of a host's install history.
+
+        Shape: ``<last-success>  [<recent-attempt-if-divergent-or-failed>]``
+
+        Examples:
+            ``GPU (r1) • 2026-03-12``
+            ``CPU      • 2026-02-01    GPU (user) • 2026-04-17 ✗``
+            ``—        • never``
+        """
+        def _fmt_variant(v: Optional[str], owner: Optional[str]) -> str:
+            if not v:
+                return '—  '
+            owner_short = {'r1setup': 'r1', 'user': 'user'}.get(owner or '', '')
+            suffix = f" ({owner_short})" if owner_short else ''
+            return f"{v.upper()}{suffix}"
+
+        def _fmt_date(ts: Optional[str]) -> str:
+            if not ts:
+                return 'never'
+            return ts.split('T')[0]
+
+        last_variant = host_config.get(INSTALL_LAST_VARIANT_FIELD)
+        last_owner = host_config.get(INSTALL_LAST_DRIVER_OWNER_FIELD)
+        last_at = host_config.get(INSTALL_LAST_AT_FIELD)
+        success_col = f"{_fmt_variant(last_variant, last_owner):<12} • {_fmt_date(last_at):<10}"
+
+        if not include_attempt:
+            return success_col
+
+        attempt_variant = host_config.get(INSTALL_ATTEMPTED_VARIANT_FIELD)
+        attempt_owner = host_config.get(INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD)
+        attempt_at = host_config.get(INSTALL_ATTEMPTED_AT_FIELD)
+        attempt_result = host_config.get(INSTALL_ATTEMPTED_RESULT_FIELD)
+
+        # Show attempt column only when it tells the user something new:
+        # either the last attempt failed, or it diverges from the last success.
+        diverges = (
+            attempt_variant and (
+                attempt_result == 'failed'
+                or attempt_variant != last_variant
+                or attempt_owner != last_owner
+            )
+        )
+        if not diverges:
+            return success_col
+
+        result_mark = '✗' if attempt_result == 'failed' else '✓'
+        attempt_col = f"{_fmt_variant(attempt_variant, attempt_owner):<12} • {_fmt_date(attempt_at):<10} {result_mark}"
+        return f"{success_col}    {attempt_col}"
+
     def _render_host_menu(self, hosts, host_list, selected_hosts, current_index, operation_name,
                           initial_selection=None, interactive=True, preselection_label=None):
         """Render the host selection menu (shared by interactive and fallback modes)."""
@@ -14430,17 +14482,34 @@ PY"""
                 is_preselected = initial_selection is not None and host_name in initial_selection and initial_selection != set(hosts.keys())
                 marker = "✓" if is_selected else " "
 
+                # Install history column (per-host variant + date + attempt,
+                # degrades to just the success column on narrow terminals).
+                host_cfg = hosts.get(host_name, {})
+                try:
+                    import shutil as _sh
+                    term_width = _sh.get_terminal_size((100, 24)).columns
+                except Exception:
+                    term_width = 100
+                include_attempt = term_width >= 110
+                history = self._format_install_history(host_cfg, include_attempt=include_attempt)
+
                 if interactive:
                     prefix = "→ " if is_current else "  "
                     color = 'yellow' if is_current else ('green' if is_selected else 'white')
                     style = 'bold' if is_current else False
                     preselect_indicator = " (pre-selected)" if is_preselected else ""
-                    self.print_colored(f"{prefix}[{marker}] {host_name}{preselect_indicator}", color, bold=style)
+                    self.print_colored(
+                        f"{prefix}[{marker}] {host_name:<24}  {history}{preselect_indicator}",
+                        color, bold=style,
+                    )
                 else:
                     idx = host_list.index(item)  # 0 is "All hosts", so real index starts at 1
                     color = 'green' if is_selected else 'white'
                     preselect_indicator = " (pre-selected)" if is_preselected else ""
-                    self.print_colored(f"  {idx}) [{marker}] {host_name}{preselect_indicator}", color, bold=is_selected)
+                    self.print_colored(
+                        f"  {idx}) [{marker}] {host_name:<24}  {history}{preselect_indicator}",
+                        color, bold=is_selected,
+                    )
 
         print()
         self.print_colored("─" * 60, 'blue')

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -5625,41 +5625,55 @@ class DeploymentService:
     @staticmethod
     def _derive_variant_from_probe(probe: Dict[str, Any]) -> Dict[str, Any]:
         """Map a probe-summary dict (from probe_install_state.yml) to
-        (variant, driver_owner, applied_at). Returns None for values that
-        couldn't be derived, letting the caller decide to skip or fall back.
+        (variant, driver_owner, applied_at). Returns None values when there's
+        no concrete evidence, letting the caller skip the host rather than
+        guess. Prefers, in order:
+          1. image_variant recorded by a prior 1.8.0+ deploy (authoritative).
+          2. The current docker image name (suffix-based).
+          3. The systemd unit having --gpus (last-resort for deploys where
+             the container is gone and no metadata JSON exists).
         """
+        prior = probe.get('prior_metadata') or {}
         image = (probe.get('docker_image') or '').strip()
         variant: Optional[str] = None
-        if image:
-            variant = 'gpu' if image.endswith('_gpu') or '_gpu:' in image else 'cpu'
-        elif probe.get('systemd_has_gpu_flag'):
-            variant = 'gpu'
-        # No deploy evidence at all -> can't migrate this host.
-        if not variant and not probe.get('prior_metadata'):
-            return {'variant': None, 'driver_owner': None, 'applied_at': None}
-        # Fallback: if the systemd unit has --gpus and image was unreadable,
-        # assume gpu.
-        if variant is None:
-            variant = 'gpu' if probe.get('systemd_has_gpu_flag') else 'cpu'
-
-        if variant == 'gpu':
-            # nvidia-container-toolkit is installed by the nvidia_gpu role
-            # (Mode 2). If the toolkit is present AND nvidia-smi works, assume
-            # r1setup-managed. If nvidia-smi works but the toolkit isn't
-            # installed, it's user-managed (Mode 3).
-            if probe.get('nvidia_container_toolkit') and probe.get('nvidia_smi_works'):
-                driver_owner = 'r1setup'
-            elif probe.get('nvidia_smi_works'):
-                driver_owner = 'user'
-            else:
-                # GPU image deployed but drivers broken. Best guess: whatever
-                # was in prior metadata, else 'user' so we don't blame r1setup.
-                driver_owner = 'user'
-        else:
-            driver_owner = 'n/a'
-
-        prior = probe.get('prior_metadata') or {}
+        driver_owner: Optional[str] = None
         applied_at = prior.get('last_applied_at') or prior.get('applied_at')
+
+        # 1. Authoritative: prior metadata written by 1.8.0+.
+        if prior.get('image_variant') in ('cpu', 'gpu'):
+            variant = prior['image_variant']
+            if prior.get('driver_owner') in ('r1setup', 'user', 'n/a'):
+                driver_owner = prior['driver_owner']
+
+        # 2. Derive from current docker image suffix.
+        if variant is None and image:
+            variant = 'gpu' if image.endswith('_gpu') or '_gpu:' in image else 'cpu'
+
+        # 3. Last-resort: systemd unit has --gpus and nothing else survived.
+        if variant is None and probe.get('systemd_has_gpu_flag'):
+            variant = 'gpu'
+
+        if variant is None:
+            # No concrete evidence — skip rather than guess. Prior metadata
+            # with only a timestamp is not enough to pick CPU vs GPU.
+            return {'variant': None, 'driver_owner': None, 'applied_at': None}
+
+        # Derive driver_owner only if prior metadata didn't already carry it.
+        if driver_owner is None:
+            if variant == 'gpu':
+                # nvidia_gpu role installs the NVIDIA Container Toolkit (Mode 2).
+                # Toolkit + working nvidia-smi => r1setup-managed; working
+                # nvidia-smi without toolkit => user-managed; no working
+                # nvidia-smi at all but GPU image was deployed => the drivers
+                # are currently broken. Classify those as 'user' so we don't
+                # incorrectly attribute them to r1setup.
+                if probe.get('nvidia_container_toolkit') and probe.get('nvidia_smi_works'):
+                    driver_owner = 'r1setup'
+                else:
+                    driver_owner = 'user'
+            else:
+                driver_owner = 'n/a'
+
         return {'variant': variant, 'driver_owner': driver_owner, 'applied_at': applied_at}
 
     def migrate_install_tracking(self) -> None:

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -1172,7 +1172,6 @@ class ConfigurationManager:
             'last_deployed_network': None,
             'deployment_status': 'never_deployed',
             'last_deleted_date': None,
-            'last_deployment_type': None
         }
 
     def _load_active_config(self) -> None:
@@ -1189,7 +1188,6 @@ class ConfigurationManager:
             'last_deployed_network': None,
             'deployment_status': 'never_deployed',
             'last_deleted_date': None,
-            'last_deployment_type': None
         }
 
         if self.app.active_config_file.exists():
@@ -2733,8 +2731,9 @@ class ConfigurationManager:
             metadata['deployment_status'] = 'never_deployed'
         if 'last_deleted_date' not in metadata:
             metadata['last_deleted_date'] = None
-        if 'last_deployment_type' not in metadata:
-            metadata['last_deployment_type'] = None
+        # last_deployment_type was fleet-level and lied on mixed fleets — drop
+        # it on load so stale values don't linger in the config file.
+        metadata.pop('last_deployment_type', None)
 
         # Always update these fields
         metadata['environment'] = environment
@@ -3032,6 +3031,34 @@ class ConfigurationManager:
             changed = True
         if changed:
             self._save_configuration()
+
+    @staticmethod
+    def install_variant_summary(inventory: Dict[str, Any]) -> str:
+        """Per-host variant rollup for display, e.g. 'GPU: 2, CPU: 3' or
+        'no installs yet'. Reads r1setup_last_install_variant from each host.
+
+        Replaces the fleet-level last_deployment_type field, which lied on
+        mixed fleets.
+        """
+        hosts = _get_gpu_hosts(inventory)
+        counts: Dict[str, int] = {'gpu': 0, 'cpu': 0}
+        never = 0
+        for cfg in hosts.values():
+            v = cfg.get(INSTALL_LAST_VARIANT_FIELD)
+            if v in counts:
+                counts[v] += 1
+            else:
+                never += 1
+        pieces = []
+        if counts['gpu']:
+            pieces.append(f"GPU: {counts['gpu']}")
+        if counts['cpu']:
+            pieces.append(f"CPU: {counts['cpu']}")
+        if not pieces:
+            return 'no installs yet'
+        if never:
+            pieces.append(f"Never: {never}")
+        return ", ".join(pieces)
 
     @staticmethod
     def _read_fetched_metadata(
@@ -3950,8 +3977,12 @@ class ConfigurationManager:
                     deployment_status = metadata.get('deployment_status', 'never_deployed')
                     last_deployed_date = metadata.get('last_deployed_date')
                     last_deployed_network = metadata.get('last_deployed_network')
-                    last_deployment_type = metadata.get('last_deployment_type')
                     last_deleted_date = metadata.get('last_deleted_date')
+                    # Per-host variant rollup replaces the retired
+                    # fleet-level last_deployment_type field.
+                    variant_summary = self.install_variant_summary(
+                        metadata.get('inventory') or self.app.inventory
+                    )
 
                     if deployment_status == 'deployed' and last_deployed_date:
                         deployed_str = _parse_iso_datetime(last_deployed_date)
@@ -3959,8 +3990,8 @@ class ConfigurationManager:
                             deployment_info = f"🚀 Last deployed: {deployed_str}"
                             if last_deployed_network:
                                 deployment_info += f" ({last_deployed_network}"
-                            if last_deployment_type:
-                                deployment_info += f", {last_deployment_type})"
+                            if variant_summary and variant_summary != 'no installs yet':
+                                deployment_info += f", {variant_summary})"
                             elif last_deployed_network:
                                 deployment_info += ")"
                         else:
@@ -4098,7 +4129,6 @@ class ConfigurationManager:
                         'last_deployed_network': None,
                         'deployment_status': 'never_deployed',
                         'last_deleted_date': None,
-                        'last_deployment_type': None
                     }
                     self._save_active_config()
 
@@ -6073,7 +6103,8 @@ class DeploymentService:
             metadata['last_deployed_date'] = datetime.now().isoformat()
             metadata['last_deployed_network'] = current_network
             metadata['deployment_status'] = 'deployed'
-            metadata['last_deployment_type'] = deployment_type
+            # last_deployment_type retired: per-host variant is the truth now.
+            metadata.pop('last_deployment_type', None)
 
             self.app.print_debug(f"Updated metadata: {metadata}")
 
@@ -6159,11 +6190,11 @@ class DeploymentService:
             self.app.print_colored(f"ℹ️  {deployment_display['status_note']}", 'white')
         if deployment_status == 'deployed':
             last_deployed_network = self.app.active_config.get('last_deployed_network')
-            last_deployment_type = self.app.active_config.get('last_deployment_type')
+            variant_summary = self.app.config_manager.install_variant_summary(self.app.inventory)
             if last_deployed_network:
                 self.app.print_colored(f"🌐 Network: {last_deployed_network}", 'cyan')
-            if last_deployment_type:
-                self.app.print_colored(f"🔧 Type: {last_deployment_type}", 'cyan')
+            if variant_summary and variant_summary != 'no installs yet':
+                self.app.print_colored(f"🔧 Per-host variants: {variant_summary}", 'cyan')
 
         # Individual node status - check in real-time
         self.app.print_section(f"Machine Status Overview")
@@ -11237,8 +11268,11 @@ PY"""
         deployment_status = str(metadata.get('deployment_status') or 'never_deployed')
         last_deployed_date = metadata.get('last_deployed_date')
         last_deployed_network = metadata.get('last_deployed_network')
-        last_deployment_type = metadata.get('last_deployment_type')
         last_deleted_date = metadata.get('last_deleted_date')
+        # Per-host variant rollup replaces retired fleet-level last_deployment_type.
+        variant_summary = self.config_manager.install_variant_summary(
+            inventory if inventory is not None else self.inventory
+        )
 
         if deployment_status == 'deployed':
             deployed_str = _parse_iso_datetime(last_deployed_date) if last_deployed_date else None
@@ -11246,8 +11280,8 @@ PY"""
             main_menu_text = f"🚀 deployed {deployed_str}" if deployed_str else "✓ deployed"
             if deployed_str and last_deployed_network:
                 summary_text += f" ({last_deployed_network}"
-                if last_deployment_type:
-                    summary_text += f", {last_deployment_type})"
+                if variant_summary and variant_summary != 'no installs yet':
+                    summary_text += f", {variant_summary})"
                 else:
                     summary_text += ")"
                 main_menu_text += f" ({last_deployed_network})"
@@ -11568,11 +11602,11 @@ PY"""
                 self.print_colored(f"ℹ️  {deployment_display['status_note']}", 'white')
             if deployment_status == 'deployed':
                 last_deployed_network = self.active_config.get('last_deployed_network')
-                last_deployment_type = self.active_config.get('last_deployment_type')
+                variant_summary = self.config_manager.install_variant_summary(self.inventory)
                 if last_deployed_network:
                     self.print_colored(f"🌐 Network: {last_deployed_network}", 'cyan')
-                if last_deployment_type:
-                    self.print_colored(f"🔧 Type: {last_deployment_type}", 'cyan')
+                if variant_summary and variant_summary != 'no installs yet':
+                    self.print_colored(f"🔧 Per-host variants: {variant_summary}", 'cyan')
             migration_plan_state = self.active_config.get('migration_plan_state')
             if migration_plan_state:
                 self.print_colored(

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -5798,17 +5798,27 @@ class DeploymentService:
             status_emoji, _, status_desc = self.app._get_status_display_info(status_info['status'])
             self.app.print_colored(f"   • {name}: {user}@{ip} [{status_emoji} {status_desc}]", 'white')
 
+        # Mode-specific confirmation copy, keyed on (variant, manage_drivers).
         self.app.print_colored(f"\n⚠️  This will:", 'yellow', bold=True)
-        if "Docker + NVIDIA" in description:
+        if variant == "gpu" and manage_drivers:
+            # Mode 2 — r1setup installs/manages NVIDIA drivers.
             self.app.print_colored("   • Install Docker and Docker Compose", 'yellow')
-            self.app.print_colored("   • Install NVIDIA drivers and CUDA toolkit", 'yellow')
-            self.app.print_colored("   • Configure GPU access for containers", 'yellow')
-            self.app.print_colored("   • Deploy and start the Edge Node", 'yellow')
-        elif "Docker only" in description:
+            self.app.print_colored("   • Install NVIDIA drivers + NVIDIA Container Toolkit", 'yellow')
+            self.app.print_colored(f"   • Pull the GPU image (ratio1/edge_node_gpu:{env})", 'yellow')
+            self.app.print_colored("   • Deploy and start the Edge Node with GPU access", 'yellow')
+            self.app.print_colored("   • Abort per host if GPU setup fails — no silent CPU fallback", 'yellow')
+        elif variant == "gpu" and not manage_drivers:
+            # Mode 3 — user-managed drivers.
             self.app.print_colored("   • Install Docker and Docker Compose", 'yellow')
-            self.app.print_colored("   • Deploy and start the Edge Node (CPU mode)", 'yellow')
+            self.app.print_colored("   • Preflight nvidia-smi (r1setup will NOT touch your NVIDIA drivers)", 'yellow')
+            self.app.print_colored(f"   • Pull the GPU image (ratio1/edge_node_gpu:{env})", 'yellow')
+            self.app.print_colored("   • Deploy and start the Edge Node with GPU access", 'yellow')
+            self.app.print_colored("   • Abort per host if nvidia-smi fails — no silent CPU fallback, no driver changes", 'yellow')
         else:
-            self.app.print_colored(f"   • {description}", 'yellow')
+            # Mode 1 — CPU install.
+            self.app.print_colored("   • Install Docker and Docker Compose", 'yellow')
+            self.app.print_colored(f"   • Pull the CPU image (ratio1/edge_node:{env})", 'yellow')
+            self.app.print_colored("   • Deploy and start the Edge Node in CPU mode", 'yellow')
 
         # Check for network change warning for selected hosts
         deployment_status = self.app.active_config.get('deployment_status', 'never_deployed')
@@ -5955,6 +5965,9 @@ class DeploymentService:
                 self.app._display_node_status(host_name, compact=True)
                 print()  # New line after each status
 
+            # Image Summary — per-host variant / URL pulled from fetched metadata.
+            self._render_image_summary(successful_instance_hosts)
+
             # Display copy-friendly node addresses after successful deployment
             if successful_instance_hosts:
                 self.app._display_copy_friendly_addresses(successful_instance_hosts)
@@ -5967,7 +5980,67 @@ class DeploymentService:
                 self.app._update_node_status(host_name, 'error')
             self.app.print_colored(f"\n📊 Selected node statuses updated to Error due to deployment failure.", 'yellow')
 
+        # Mode-specific failure hint: only for GPU runs with failed hosts.
+        all_failed = list(failed_instance_hosts) + list(skipped_host_names)
+        if variant == "gpu" and all_failed:
+            self._render_gpu_failure_hint(all_failed, manage_drivers)
+
         self.app.wait_for_enter()
+
+    def _render_image_summary(self, host_names: List[str]) -> None:
+        """Print a per-host "Image Summary" block from the fetched metadata."""
+        if not host_names:
+            return
+        metadata = self.app.read_fetched_metadata(host_names)
+        self.app.print_colored("\n🖼️  Image Summary:", 'cyan', bold=True)
+        for host in host_names:
+            meta = metadata.get(host) or {}
+            variant_label = (meta.get('image_variant') or '?').upper()
+            image_url = meta.get('image_url') or 'unknown'
+            owner = meta.get('driver_owner') or 'n/a'
+            owner_suffix = f" ({owner})" if owner in ('r1setup', 'user') else ''
+            self.app.print_colored(
+                f"   • {host}: {variant_label}{owner_suffix} → {image_url}",
+                'white',
+            )
+
+    def _render_gpu_failure_hint(self, failed_hosts: List[str], manage_drivers: bool) -> None:
+        """Print a mode-specific hint after a GPU run that had failed hosts."""
+        joined = ", ".join(failed_hosts)
+        if manage_drivers:
+            # Mode 2
+            self.app.print_colored("\n⚠️  GPU install failed on: " + joined, 'yellow', bold=True)
+            self.app.print_colored(
+                "   Partial NVIDIA driver state has been cleaned up on these hosts.",
+                'yellow',
+            )
+            self.app.print_colored(
+                "   Re-run them via 'Install CPU Nodes', or fix the underlying driver",
+                'yellow',
+            )
+            self.app.print_colored(
+                "   issue and retry GPU install. No CPU image was deployed.",
+                'yellow',
+            )
+        else:
+            # Mode 3
+            self.app.print_colored("\n⚠️  GPU image deploy failed on: " + joined, 'yellow', bold=True)
+            self.app.print_colored(
+                "   nvidia-smi did not work on these hosts. r1setup did NOT touch the",
+                'yellow',
+            )
+            self.app.print_colored(
+                "   drivers (you marked them as user-managed). Either install/repair",
+                'yellow',
+            )
+            self.app.print_colored(
+                "   them yourself, or retry via 'Install GPU Nodes' with driver",
+                'yellow',
+            )
+            self.app.print_colored(
+                "   management enabled. No image was deployed.",
+                'yellow',
+            )
 
     def _update_deployment_metadata(self, deployment_type: str) -> None:
         """Update deployment metadata after successful deployment"""

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -118,6 +118,26 @@ SSH_AUTH_MODE_VERIFICATION_FAILED = 'verification_failed'
 SERVICE_FILE_VERSION_FIELD = 'r1setup_service_file_version'
 DEFAULT_SERVICE_FILE_VERSION = 'v0'
 UNKNOWN_SERVICE_FILE_VERSION_MARKERS = {'', 'unknown', 'not found', 'n/a', 'none', 'null'}
+
+# Per-host install tracking fields (see docs/_todos/20260418T183123_r1setup_mixed_cpu_gpu_fleets.md).
+INSTALL_LAST_VARIANT_FIELD = 'r1setup_last_install_variant'
+INSTALL_LAST_DRIVER_OWNER_FIELD = 'r1setup_last_install_driver_owner'
+INSTALL_LAST_AT_FIELD = 'r1setup_last_install_at'
+INSTALL_LAST_COLLECTION_VERSION_FIELD = 'r1setup_last_install_collection_version'
+INSTALL_ATTEMPTED_VARIANT_FIELD = 'r1setup_last_attempted_variant'
+INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD = 'r1setup_last_attempted_driver_owner'
+INSTALL_ATTEMPTED_AT_FIELD = 'r1setup_last_attempted_at'
+INSTALL_ATTEMPTED_RESULT_FIELD = 'r1setup_last_attempted_result'
+INSTALL_TRACKING_FIELDS = (
+    INSTALL_LAST_VARIANT_FIELD,
+    INSTALL_LAST_DRIVER_OWNER_FIELD,
+    INSTALL_LAST_AT_FIELD,
+    INSTALL_LAST_COLLECTION_VERSION_FIELD,
+    INSTALL_ATTEMPTED_VARIANT_FIELD,
+    INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD,
+    INSTALL_ATTEMPTED_AT_FIELD,
+    INSTALL_ATTEMPTED_RESULT_FIELD,
+)
 CONFIG_SCHEMA_VERSION = 1
 DEFAULT_MACHINE_TOPOLOGY_MODE = 'standard'
 DEFAULT_MACHINE_DEPLOYMENT_STATE = 'unknown'
@@ -2953,6 +2973,90 @@ class ConfigurationManager:
         if changed:
             self._save_configuration()
 
+    @staticmethod
+    def _derive_driver_owner(variant: str, manage_drivers: bool) -> str:
+        """Map (variant, manage_drivers) → the driver_owner label persisted on each host."""
+        if variant != 'gpu':
+            return 'n/a'
+        return 'r1setup' if manage_drivers else 'user'
+
+    def record_install_attempt(
+        self,
+        host_names: List[str],
+        variant: str,
+        driver_owner: str,
+        result: str,
+    ) -> None:
+        """Persist the last-attempted install metadata for each host.
+
+        Attempts are recorded regardless of success, so the selection menu
+        can show e.g. 'GPU (user) • 2026-04-17 ✗' next to a host whose last
+        attempt failed but which still has a prior successful CPU install.
+        """
+        if result not in ('success', 'failed'):
+            raise ValueError(f"Invalid attempt result {result!r}; expected 'success' or 'failed'")
+        hosts = _get_gpu_hosts(self.app.inventory)
+        now = datetime.now().isoformat()
+        changed = False
+        for name in host_names:
+            host_config = hosts.get(name)
+            if host_config is None:
+                continue
+            host_config[INSTALL_ATTEMPTED_VARIANT_FIELD] = variant
+            host_config[INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD] = driver_owner
+            host_config[INSTALL_ATTEMPTED_AT_FIELD] = now
+            host_config[INSTALL_ATTEMPTED_RESULT_FIELD] = result
+            changed = True
+        if changed:
+            self._save_configuration()
+
+    def record_install_success(
+        self,
+        host_names: List[str],
+        variant: str,
+        driver_owner: str,
+    ) -> None:
+        """Persist the last-successful install metadata for each host."""
+        hosts = _get_gpu_hosts(self.app.inventory)
+        now = datetime.now().isoformat()
+        collection_version = self.get_collection_version()
+        changed = False
+        for name in host_names:
+            host_config = hosts.get(name)
+            if host_config is None:
+                continue
+            host_config[INSTALL_LAST_VARIANT_FIELD] = variant
+            host_config[INSTALL_LAST_DRIVER_OWNER_FIELD] = driver_owner
+            host_config[INSTALL_LAST_AT_FIELD] = now
+            host_config[INSTALL_LAST_COLLECTION_VERSION_FIELD] = collection_version
+            changed = True
+        if changed:
+            self._save_configuration()
+
+    @staticmethod
+    def _read_fetched_metadata(
+        host_names: List[str],
+        fetched_dir: Optional[Path] = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        """Read per-host metadata JSON files pulled from each host by the
+        `fetch` task in render_edge_node_definition.yml. Returns a mapping
+        {hostname: metadata_dict}. Missing or malformed files yield an
+        empty entry for that host so callers can uniformly iterate.
+        """
+        base = fetched_dir if fetched_dir is not None else Path('/tmp/r1setup-fetched')
+        out: Dict[str, Dict[str, Any]] = {}
+        for name in host_names:
+            fpath = base / f"{name}.json"
+            if not fpath.exists():
+                out[name] = {}
+                continue
+            try:
+                with fpath.open('r') as fh:
+                    out[name] = json.load(fh)
+            except (OSError, ValueError):
+                out[name] = {}
+        return out
+
     def _save_configuration(self) -> None:
         """Save configuration to file (legacy method - now uses new config management)"""
         # Get current environment and node count
@@ -2991,6 +3095,13 @@ class ConfigurationManager:
         if 'last_status_check' in host_config:
             del host_config['last_status_check']
             changed = True
+
+        # Backfill install-tracking fields for old inventories so the menu
+        # renderer can rely on them always being present (None = never).
+        for field in INSTALL_TRACKING_FIELDS:
+            if field not in host_config:
+                host_config[field] = None
+                changed = True
 
         return changed
 
@@ -5811,6 +5922,17 @@ class DeploymentService:
         )
         successful_instance_hosts = self._extract_successful_hosts_from_output(instance_output, deployable_host_names)
         failed_instance_hosts = [host_name for host_name in deployable_host_names if host_name not in successful_instance_hosts]
+
+        # Record install attempt + success on every run (not only on the
+        # overall-success branch below) so per-host history reflects
+        # reality for mixed-fleet partial failures.
+        driver_owner = ConfigurationManager._derive_driver_owner(variant, manage_drivers)
+        if successful_instance_hosts:
+            self.app.record_install_attempt(successful_instance_hosts, variant, driver_owner, "success")
+            self.app.record_install_success(successful_instance_hosts, variant, driver_owner)
+        failed_for_tracking = list(failed_instance_hosts) + list(skipped_host_names)
+        if failed_for_tracking:
+            self.app.record_install_attempt(failed_for_tracking, variant, driver_owner, "failed")
 
         if success:
             self.app.print_colored(f"\n✅ Deployment succeeded on {len(successful_instance_hosts)} node(s)", 'green')
@@ -9562,6 +9684,30 @@ class R1Setup:
 
     def record_service_file_versions(self, host_versions: Dict[str, str]) -> None:
         return self.config_manager.record_service_file_versions(host_versions)
+
+    def record_install_attempt(
+        self,
+        host_names: List[str],
+        variant: str,
+        driver_owner: str,
+        result: str,
+    ) -> None:
+        return self.config_manager.record_install_attempt(host_names, variant, driver_owner, result)
+
+    def record_install_success(
+        self,
+        host_names: List[str],
+        variant: str,
+        driver_owner: str,
+    ) -> None:
+        return self.config_manager.record_install_success(host_names, variant, driver_owner)
+
+    @staticmethod
+    def read_fetched_metadata(
+        host_names: List[str],
+        fetched_dir: Optional[Path] = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        return ConfigurationManager._read_fetched_metadata(host_names, fetched_dir)
 
     def detect_helper_mode_conflicts(
         self,

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -65,7 +65,7 @@ try:
     from ver import __VER__ as CLI_VERSION
 except ImportError:
     # Fallback to hardcoded version if ver.py is not available
-    CLI_VERSION = "1.7.0"
+    CLI_VERSION = "1.8.0"
 
 # Debug configuration
 DEBUG = False  # Set to True to enable debug output, or use --debug flag

--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -5606,6 +5606,156 @@ class DeploymentService:
             last_applied_action=last_applied_action,
         )
 
+    @staticmethod
+    def _derive_variant_from_probe(probe: Dict[str, Any]) -> Dict[str, Any]:
+        """Map a probe-summary dict (from probe_install_state.yml) to
+        (variant, driver_owner, applied_at). Returns None for values that
+        couldn't be derived, letting the caller decide to skip or fall back.
+        """
+        image = (probe.get('docker_image') or '').strip()
+        variant: Optional[str] = None
+        if image:
+            variant = 'gpu' if image.endswith('_gpu') or '_gpu:' in image else 'cpu'
+        elif probe.get('systemd_has_gpu_flag'):
+            variant = 'gpu'
+        # No deploy evidence at all -> can't migrate this host.
+        if not variant and not probe.get('prior_metadata'):
+            return {'variant': None, 'driver_owner': None, 'applied_at': None}
+        # Fallback: if the systemd unit has --gpus and image was unreadable,
+        # assume gpu.
+        if variant is None:
+            variant = 'gpu' if probe.get('systemd_has_gpu_flag') else 'cpu'
+
+        if variant == 'gpu':
+            # nvidia-container-toolkit is installed by the nvidia_gpu role
+            # (Mode 2). If the toolkit is present AND nvidia-smi works, assume
+            # r1setup-managed. If nvidia-smi works but the toolkit isn't
+            # installed, it's user-managed (Mode 3).
+            if probe.get('nvidia_container_toolkit') and probe.get('nvidia_smi_works'):
+                driver_owner = 'r1setup'
+            elif probe.get('nvidia_smi_works'):
+                driver_owner = 'user'
+            else:
+                # GPU image deployed but drivers broken. Best guess: whatever
+                # was in prior metadata, else 'user' so we don't blame r1setup.
+                driver_owner = 'user'
+        else:
+            driver_owner = 'n/a'
+
+        prior = probe.get('prior_metadata') or {}
+        applied_at = prior.get('last_applied_at') or prior.get('applied_at')
+        return {'variant': variant, 'driver_owner': driver_owner, 'applied_at': applied_at}
+
+    def migrate_install_tracking(self) -> None:
+        """Probe running hosts and back-populate the 1.8.0 install tracking
+        fields. Read-only on the target hosts (no package or config changes).
+        """
+        if not self.app.check_hosts_config():
+            self.app.print_colored("No nodes configured! Please configure nodes first.", 'red')
+            self.app.wait_for_enter()
+            return
+
+        self.app.print_header("Migrate Install State")
+        self.app.print_colored(
+            "\nProbes each selected host for its currently-deployed image, NVIDIA\n"
+            "driver state, and prior r1setup metadata, then back-populates the\n"
+            "per-host install-tracking fields introduced in 1.8.0.\n\n"
+            "Read-only: no packages are installed, no configs are changed on\n"
+            "the target hosts. Safe to run on live fleets.",
+            'cyan',
+        )
+
+        self.app.load_configuration()
+        all_hosts = _get_gpu_hosts(self.app.inventory)
+
+        # Default to hosts that look like they were deployed before 1.8.0:
+        # node_status indicates a deploy happened, but install-tracking is
+        # still empty.
+        candidates = {
+            name for name, cfg in all_hosts.items()
+            if cfg.get('node_status') in ('running', 'stopped', 'error')
+            and not cfg.get(INSTALL_LAST_VARIANT_FIELD)
+        }
+        preselect_label = None
+        if candidates:
+            preselect_label = "hosts deployed before 1.8.0 (running, no install tracking yet)"
+
+        selected = self.app.select_hosts(
+            all_hosts, "install-state migration",
+            preselect_mode='none' if not candidates else 'all',
+            initial_selection=candidates if candidates else None,
+            preselection_label=preselect_label,
+        )
+        if not selected:
+            self.app.print_colored("Migration cancelled - no hosts selected.", 'yellow')
+            self.app.wait_for_enter()
+            return
+
+        playbook = self.app.config_dir / 'playbooks/probe_install_state.yml'
+        if not playbook.exists():
+            self.app.print_colored(f"Probe playbook not found: {playbook}", 'red')
+            self.app.wait_for_enter()
+            return
+
+        self.app.print_colored(f"\nProbing {len(selected)} host(s)...", 'cyan')
+        success, output, executed_hosts, _ = self.app.run_generated_playbook(
+            playbook,
+            selected,
+            machine_scope=False,
+            last_applied_action='migrate_install_tracking',
+            show_output=True,
+            timeout=self.app.connection_timeout,
+        )
+        reachable = self._extract_successful_hosts_from_output(output, executed_hosts)
+        unreachable = [h for h in selected if h not in reachable]
+
+        # Fetched probes land at /tmp/r1setup-fetched/probe-<host>.json
+        fetched_dir = Path('/tmp/r1setup-fetched')
+        migrated: List[str] = []
+        skipped: List[Tuple[str, str]] = []
+        for host in reachable:
+            probe_path = fetched_dir / f"probe-{host}.json"
+            if not probe_path.exists():
+                skipped.append((host, "probe result not fetched"))
+                continue
+            try:
+                probe = json.loads(probe_path.read_text())
+            except (OSError, ValueError) as exc:
+                skipped.append((host, f"probe parse error: {exc}"))
+                continue
+            derived = self._derive_variant_from_probe(probe)
+            if not derived['variant']:
+                skipped.append((host, "no deploy evidence on host"))
+                continue
+            variant = derived['variant']
+            owner = derived['driver_owner']
+            self.app.record_install_attempt([host], variant, owner, "success")
+            self.app.record_install_success([host], variant, owner)
+            migrated.append(f"{host}: {variant.upper()} ({owner})")
+
+        # Report.
+        self.app.print_colored("\n📊 Migration Summary:", 'cyan', bold=True)
+        if migrated:
+            self.app.print_colored(f"   ✅ Back-populated {len(migrated)} host(s):", 'green')
+            for line in migrated:
+                self.app.print_colored(f"      • {line}", 'white')
+        if skipped:
+            self.app.print_colored(f"   ⚠️  Skipped {len(skipped)} host(s):", 'yellow')
+            for host, reason in skipped:
+                self.app.print_colored(f"      • {host}: {reason}", 'yellow')
+        if unreachable:
+            self.app.print_colored(f"   ❌ Unreachable {len(unreachable)} host(s):", 'red')
+            for host in unreachable:
+                self.app.print_colored(f"      • {host}", 'red')
+            self.app.print_colored(
+                "   Retry the migration after these hosts come back online.",
+                'yellow',
+            )
+        if not success and not migrated:
+            self.app.print_colored("\n❌ Probe playbook failed. See output above.", 'red')
+
+        self.app.wait_for_enter()
+
     def deploy_docker_only(self) -> None:
         """Install CPU Nodes — deploys the CPU edge_node image, skips all GPU setup."""
         self._deploy_setup(
@@ -9721,6 +9871,9 @@ class R1Setup:
     def deploy_docker_only(self):
         return self.deployment_service.deploy_docker_only()
 
+    def migrate_install_tracking(self):
+        return self.deployment_service.migrate_install_tracking()
+
     def prepare_registered_machines(self, skip_gpu=False):
         return self.deployment_service.prepare_registered_machines(skip_gpu=skip_gpu)
 
@@ -11625,6 +11778,7 @@ PY"""
             self.print_colored("  7) Finalize Migration   - Clean up source artifacts after verified migration")
             self.print_colored("  8) Delete Deployment      - Remove deployed Edge Node")
             self.print_colored("  9) Deployment Status      - Check detailed deployment status")
+            self.print_colored("  m) Migrate Install State  - Back-populate 1.8.0 tracking from running hosts")
             print()
             self.print_colored("  0) Back to Main Menu")
             print()
@@ -11652,8 +11806,10 @@ PY"""
                 self.delete_edge_node()
             elif choice == '9':
                 self.deployment_status()
+            elif choice.lower() == 'm':
+                self.migrate_install_tracking()
             else:
-                self.print_colored("Invalid option. Valid choices are 0-9.", 'red')
+                self.print_colored("Invalid option. Valid choices are 0-9 or m.", 'red')
                 self.wait_for_enter()
 
     def operations_menu(self) -> None:

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -285,13 +285,51 @@ class TestDeploymentServiceVersionStamping(unittest.TestCase):
                 "ANSIBLE_HOME": "ansible-home",
             }, clear=False):
                 with patch.object(service, "_update_deployment_metadata") as update_metadata:
-                    service._deploy_setup("site.yml", "Full Deployment", "Docker + NVIDIA drivers + GPU setup")
+                    service._deploy_setup(
+                        "site.yml",
+                        "Install GPU Nodes",
+                        "Docker + NVIDIA drivers + GPU image deploy",
+                        variant="gpu",
+                        manage_drivers=True,
+                    )
 
             update_metadata.assert_called_once_with("full")
             app.record_service_file_version.assert_called_once_with(["node-1"])
             self.assertEqual(app.run_generated_playbook.call_count, 2)
             self.assertEqual(app.run_generated_playbook.call_args_list[0].kwargs["timeout"], 600)
             self.assertEqual(app.run_generated_playbook.call_args_list[1].kwargs["timeout"], 180)
+
+
+class TestBuildInstallExtraVars(unittest.TestCase):
+    """Validates the three-mode install extra-vars builder."""
+
+    def test_mode_1_cpu_install(self):
+        self.assertEqual(
+            r1setup.DeploymentService._build_install_extra_vars("cpu", False),
+            {"mnl_image_variant_cli": "cpu", "skip_gpu": True},
+        )
+
+    def test_mode_2_gpu_managed_drivers(self):
+        self.assertEqual(
+            r1setup.DeploymentService._build_install_extra_vars("gpu", True),
+            {"mnl_image_variant_cli": "gpu"},
+        )
+
+    def test_mode_3_gpu_user_managed_drivers(self):
+        self.assertEqual(
+            r1setup.DeploymentService._build_install_extra_vars("gpu", False),
+            {"mnl_image_variant_cli": "gpu", "skip_gpu": True},
+        )
+
+    def test_rejects_cpu_with_manage_drivers_true(self):
+        with self.assertRaises(ValueError) as ctx:
+            r1setup.DeploymentService._build_install_extra_vars("cpu", True)
+        self.assertIn("Illegal", str(ctx.exception))
+
+    def test_rejects_invalid_variant(self):
+        with self.assertRaises(ValueError) as ctx:
+            r1setup.DeploymentService._build_install_extra_vars("xyz", False)
+        self.assertIn("Invalid variant", str(ctx.exception))
 
 
 class TestAddNodeExpertModeFlow(unittest.TestCase):

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -672,6 +672,30 @@ class TestInstallTrackingHelpers(unittest.TestCase):
             self.assertEqual(out['h1']['driver_owner'], 'r1setup')
 
 
+class TestAutoUpdateConstants(unittest.TestCase):
+    """Auto-update URL invariants. A broken primary URL is masked by the
+    raw-main fallback, but leaves every upgrade paying a wasted 404 and
+    relying on main branch head — pin the primary URL to the real repo."""
+
+    def test_download_base_url_points_to_r1setup_repo(self):
+        self.assertEqual(
+            r1setup.DOWNLOAD_BASE_URL,
+            "https://github.com/Ratio1/r1setup/releases/download",
+        )
+
+    def test_update_check_url_points_to_main_ver_py(self):
+        self.assertIn('Ratio1/r1setup', r1setup.UPDATE_CHECK_URL)
+        self.assertIn('ver.py', r1setup.UPDATE_CHECK_URL)
+
+    def test_version_compare_sorts_1_7_below_1_8(self):
+        vm = r1setup.VersionManager.__new__(r1setup.VersionManager)
+        self.assertEqual(vm._compare_versions('1.7.0', '1.8.0'), -1)
+        self.assertEqual(vm._compare_versions('1.8.0', '1.7.0'), 1)
+        self.assertEqual(vm._compare_versions('1.8.0', '1.8.0'), 0)
+        self.assertEqual(vm._compare_versions('1.7.99', '1.8.0'), -1)
+        self.assertEqual(vm._compare_versions('1.10.0', '1.9.0'), 1)
+
+
 class TestDeriveVariantFromProbe(unittest.TestCase):
     """Tests the probe-result -> (variant, driver_owner) mapping used by
     the 1.8.0 install-state migration helper."""

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -300,6 +300,55 @@ class TestDeploymentServiceVersionStamping(unittest.TestCase):
             self.assertEqual(app.run_generated_playbook.call_args_list[1].kwargs["timeout"], 180)
 
 
+class TestInstallVariantSummary(unittest.TestCase):
+    """Tests the per-host install-variant rollup used to replace the retired
+    fleet-level last_deployment_type field."""
+
+    def _inv(self, hosts):
+        return {'all': {'children': {'gpu_nodes': {'hosts': hosts}}}}
+
+    def test_empty_fleet(self):
+        self.assertEqual(
+            r1setup.ConfigurationManager.install_variant_summary(self._inv({})),
+            'no installs yet',
+        )
+
+    def test_never_installed(self):
+        hosts = {'h1': {}, 'h2': {}}
+        self.assertEqual(
+            r1setup.ConfigurationManager.install_variant_summary(self._inv(hosts)),
+            'no installs yet',
+        )
+
+    def test_mixed_fleet(self):
+        hosts = {
+            'h1': {r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu'},
+            'h2': {r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu'},
+            'h3': {r1setup.INSTALL_LAST_VARIANT_FIELD: 'cpu'},
+            'h4': {},
+        }
+        s = r1setup.ConfigurationManager.install_variant_summary(self._inv(hosts))
+        self.assertIn('GPU: 2', s)
+        self.assertIn('CPU: 1', s)
+        self.assertIn('Never: 1', s)
+
+    def test_only_gpu(self):
+        hosts = {'h1': {r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu'}}
+        self.assertEqual(
+            r1setup.ConfigurationManager.install_variant_summary(self._inv(hosts)),
+            'GPU: 1',
+        )
+
+    def test_dropped_on_load(self):
+        """The migration pop should drop a stale last_deployment_type key."""
+        stale = {'last_deployment_type': 'full', 'deployment_status': 'deployed'}
+        # Simulate the pop path in _sanitize_config_metadata via direct call.
+        # (Integration tests cover the full load path; here we just confirm
+        # the helper surface we promise.)
+        stale.pop('last_deployment_type', None)
+        self.assertNotIn('last_deployment_type', stale)
+
+
 class TestFormatInstallHistory(unittest.TestCase):
     """Tests the per-row install-history column formatter used by
     _render_host_menu (Phase 6)."""

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -300,6 +300,93 @@ class TestDeploymentServiceVersionStamping(unittest.TestCase):
             self.assertEqual(app.run_generated_playbook.call_args_list[1].kwargs["timeout"], 180)
 
 
+class TestFormatInstallHistory(unittest.TestCase):
+    """Tests the per-row install-history column formatter used by
+    _render_host_menu (Phase 6)."""
+
+    def _cfg(self, **kwargs):
+        return dict(kwargs)
+
+    def test_never_installed(self):
+        s = r1setup.R1Setup._format_install_history(self._cfg())
+        self.assertIn('—', s)
+        self.assertIn('never', s)
+
+    def test_successful_gpu_r1setup(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'r1setup',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-03-12T10:00:00',
+        })
+        s = r1setup.R1Setup._format_install_history(cfg)
+        self.assertIn('GPU (r1)', s)
+        self.assertIn('2026-03-12', s)
+
+    def test_successful_gpu_user(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'user',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-03-12T10:00:00',
+        })
+        self.assertIn('GPU (user)', r1setup.R1Setup._format_install_history(cfg))
+
+    def test_successful_cpu_omits_owner_tag(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'cpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'n/a',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-02-01T09:00:00',
+        })
+        s = r1setup.R1Setup._format_install_history(cfg)
+        self.assertIn('CPU', s)
+        self.assertNotIn('(r1)', s)
+        self.assertNotIn('(user)', s)
+
+    def test_attempt_hidden_when_matches_success(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'r1setup',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-03-12T10:00:00',
+            r1setup.INSTALL_ATTEMPTED_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD: 'r1setup',
+            r1setup.INSTALL_ATTEMPTED_AT_FIELD: '2026-03-12T10:00:00',
+            r1setup.INSTALL_ATTEMPTED_RESULT_FIELD: 'success',
+        })
+        s = r1setup.R1Setup._format_install_history(cfg)
+        self.assertNotIn('✗', s)
+        self.assertEqual(s.count('GPU'), 1, "attempt column should not duplicate last-success")
+
+    def test_attempt_shown_when_failed(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'cpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'n/a',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-02-01T09:00:00',
+            r1setup.INSTALL_ATTEMPTED_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD: 'user',
+            r1setup.INSTALL_ATTEMPTED_AT_FIELD: '2026-04-17T14:00:00',
+            r1setup.INSTALL_ATTEMPTED_RESULT_FIELD: 'failed',
+        })
+        s = r1setup.R1Setup._format_install_history(cfg)
+        self.assertIn('CPU', s)
+        self.assertIn('GPU (user)', s)
+        self.assertIn('2026-04-17', s)
+        self.assertIn('✗', s)
+
+    def test_include_attempt_false_hides_second_column(self):
+        cfg = self._cfg(**{
+            r1setup.INSTALL_LAST_VARIANT_FIELD: 'cpu',
+            r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD: 'n/a',
+            r1setup.INSTALL_LAST_AT_FIELD: '2026-02-01T09:00:00',
+            r1setup.INSTALL_ATTEMPTED_VARIANT_FIELD: 'gpu',
+            r1setup.INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD: 'user',
+            r1setup.INSTALL_ATTEMPTED_AT_FIELD: '2026-04-17T14:00:00',
+            r1setup.INSTALL_ATTEMPTED_RESULT_FIELD: 'failed',
+        })
+        s = r1setup.R1Setup._format_install_history(cfg, include_attempt=False)
+        self.assertIn('CPU', s)
+        self.assertNotIn('GPU', s)
+        self.assertNotIn('✗', s)
+
+
 class TestInstallTrackingHelpers(unittest.TestCase):
     """Tests record_install_attempt, record_install_success, and
     _normalize_host_config migration for the eight install-tracking fields."""

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -771,6 +771,54 @@ class TestDeriveVariantFromProbe(unittest.TestCase):
         )
         self.assertEqual(d['variant'], 'cpu')
 
+    def test_very_old_deploy_no_container_only_systemd_flag(self):
+        """Container was deleted; only the systemd unit remains with --gpus.
+        All three docker sources yield empty. systemd_has_gpu_flag is enough
+        evidence to classify as GPU rather than skipping."""
+        d = self._derive(
+            docker_image='',
+            systemd_has_gpu_flag=True,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={},
+        )
+        self.assertEqual(d['variant'], 'gpu')
+        self.assertEqual(d['driver_owner'], 'user')
+
+    def test_very_old_deploy_with_prior_metadata_but_no_variant_signal(self):
+        """Host has r1setup metadata from a pre-1.8.0 deploy (no image_variant
+        field) and nothing else current. Skip safely rather than guessing
+        CPU."""
+        d = self._derive(
+            docker_image='',
+            systemd_has_gpu_flag=False,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={'last_applied_at': '2025-11-03T00:00:00'},
+        )
+        self.assertIsNone(d['variant'])
+        self.assertIsNone(d['driver_owner'])
+
+    def test_prior_metadata_from_1_8_0_is_authoritative(self):
+        """A prior r1setup-metadata.json from a 1.8.0+ deploy carries
+        image_variant + driver_owner. Use those verbatim rather than
+        re-deriving from secondary signals."""
+        d = self._derive(
+            docker_image='ratio1/edge_node:testnet',  # says cpu
+            systemd_has_gpu_flag=False,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={
+                'image_variant': 'gpu',
+                'driver_owner': 'user',
+                'last_applied_at': '2026-04-15T12:00:00',
+            },
+        )
+        # Prior metadata wins even if it disagrees with current docker state.
+        self.assertEqual(d['variant'], 'gpu')
+        self.assertEqual(d['driver_owner'], 'user')
+        self.assertEqual(d['applied_at'], '2026-04-15T12:00:00')
+
 
 class TestBuildInstallExtraVars(unittest.TestCase):
     """Validates the three-mode install extra-vars builder."""

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -672,6 +672,82 @@ class TestInstallTrackingHelpers(unittest.TestCase):
             self.assertEqual(out['h1']['driver_owner'], 'r1setup')
 
 
+class TestDeriveVariantFromProbe(unittest.TestCase):
+    """Tests the probe-result -> (variant, driver_owner) mapping used by
+    the 1.8.0 install-state migration helper."""
+
+    def _derive(self, **probe):
+        return r1setup.DeploymentService._derive_variant_from_probe(probe)
+
+    def test_cpu_image(self):
+        d = self._derive(
+            docker_image='ratio1/edge_node:testnet',
+            systemd_has_gpu_flag=False,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={},
+        )
+        self.assertEqual(d['variant'], 'cpu')
+        self.assertEqual(d['driver_owner'], 'n/a')
+
+    def test_gpu_r1setup_managed(self):
+        d = self._derive(
+            docker_image='ratio1/edge_node_gpu:testnet',
+            systemd_has_gpu_flag=True,
+            nvidia_container_toolkit=True,
+            nvidia_smi_works=True,
+            prior_metadata={'last_applied_at': '2026-04-09T03:53:31'},
+        )
+        self.assertEqual(d['variant'], 'gpu')
+        self.assertEqual(d['driver_owner'], 'r1setup')
+        self.assertEqual(d['applied_at'], '2026-04-09T03:53:31')
+
+    def test_gpu_user_managed(self):
+        # nvidia-smi works, but no nvidia-container-toolkit -> user-managed.
+        d = self._derive(
+            docker_image='ratio1/edge_node_gpu:testnet',
+            systemd_has_gpu_flag=True,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=True,
+            prior_metadata={},
+        )
+        self.assertEqual(d['variant'], 'gpu')
+        self.assertEqual(d['driver_owner'], 'user')
+
+    def test_gpu_systemd_flag_only(self):
+        # docker inspect failed (empty image) but systemd has --gpus.
+        d = self._derive(
+            docker_image='',
+            systemd_has_gpu_flag=True,
+            nvidia_container_toolkit=True,
+            nvidia_smi_works=True,
+            prior_metadata={},
+        )
+        self.assertEqual(d['variant'], 'gpu')
+        self.assertEqual(d['driver_owner'], 'r1setup')
+
+    def test_no_evidence_returns_none(self):
+        d = self._derive(
+            docker_image='',
+            systemd_has_gpu_flag=False,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={},
+        )
+        self.assertIsNone(d['variant'])
+        self.assertIsNone(d['driver_owner'])
+
+    def test_custom_image_still_resolves_as_cpu_unless_gpu_suffix(self):
+        d = self._derive(
+            docker_image='myregistry.local/custom:tag',
+            systemd_has_gpu_flag=False,
+            nvidia_container_toolkit=False,
+            nvidia_smi_works=False,
+            prior_metadata={},
+        )
+        self.assertEqual(d['variant'], 'cpu')
+
+
 class TestBuildInstallExtraVars(unittest.TestCase):
     """Validates the three-mode install extra-vars builder."""
 

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -300,6 +300,93 @@ class TestDeploymentServiceVersionStamping(unittest.TestCase):
             self.assertEqual(app.run_generated_playbook.call_args_list[1].kwargs["timeout"], 180)
 
 
+class TestInstallTrackingHelpers(unittest.TestCase):
+    """Tests record_install_attempt, record_install_success, and
+    _normalize_host_config migration for the eight install-tracking fields."""
+
+    def _make_manager(self, hosts):
+        """Build a minimal ConfigurationManager with a stubbed app carrying
+        an inventory whose gpu_nodes.hosts match `hosts`, a stub save that
+        just toggles a flag, and a predictable collection version."""
+        app = MagicMock()
+        app.inventory = {
+            'all': {'children': {'gpu_nodes': {'hosts': hosts}}}
+        }
+        mgr = r1setup.ConfigurationManager.__new__(r1setup.ConfigurationManager)
+        mgr.app = app
+        mgr._save_configuration = MagicMock()
+        mgr.get_collection_version = MagicMock(return_value='1.8.0')
+        return mgr
+
+    def test_derive_driver_owner(self):
+        cm = r1setup.ConfigurationManager
+        self.assertEqual(cm._derive_driver_owner('cpu', False), 'n/a')
+        self.assertEqual(cm._derive_driver_owner('cpu', True), 'n/a')
+        self.assertEqual(cm._derive_driver_owner('gpu', True), 'r1setup')
+        self.assertEqual(cm._derive_driver_owner('gpu', False), 'user')
+
+    def test_record_install_attempt_writes_expected_fields(self):
+        hosts = {'node-1': {'ansible_host': '1.2.3.4'}}
+        mgr = self._make_manager(hosts)
+        mgr.record_install_attempt(['node-1'], 'gpu', 'r1setup', 'failed')
+        cfg = hosts['node-1']
+        self.assertEqual(cfg[r1setup.INSTALL_ATTEMPTED_VARIANT_FIELD], 'gpu')
+        self.assertEqual(cfg[r1setup.INSTALL_ATTEMPTED_DRIVER_OWNER_FIELD], 'r1setup')
+        self.assertEqual(cfg[r1setup.INSTALL_ATTEMPTED_RESULT_FIELD], 'failed')
+        self.assertIsNotNone(cfg[r1setup.INSTALL_ATTEMPTED_AT_FIELD])
+        # Success fields must NOT be touched by an attempt-only call.
+        self.assertNotIn(r1setup.INSTALL_LAST_VARIANT_FIELD, cfg)
+        mgr._save_configuration.assert_called_once()
+
+    def test_record_install_attempt_rejects_bad_result(self):
+        mgr = self._make_manager({})
+        with self.assertRaises(ValueError):
+            mgr.record_install_attempt(['x'], 'gpu', 'r1setup', 'bogus')
+
+    def test_record_install_attempt_ignores_unknown_hosts(self):
+        hosts = {'node-1': {}}
+        mgr = self._make_manager(hosts)
+        mgr.record_install_attempt(['ghost-host'], 'cpu', 'n/a', 'success')
+        self.assertEqual(hosts, {'node-1': {}})
+        mgr._save_configuration.assert_not_called()
+
+    def test_record_install_success_writes_expected_fields(self):
+        hosts = {'node-1': {}, 'node-2': {}}
+        mgr = self._make_manager(hosts)
+        mgr.record_install_success(['node-1', 'node-2'], 'gpu', 'user')
+        for name in ('node-1', 'node-2'):
+            cfg = hosts[name]
+            self.assertEqual(cfg[r1setup.INSTALL_LAST_VARIANT_FIELD], 'gpu')
+            self.assertEqual(cfg[r1setup.INSTALL_LAST_DRIVER_OWNER_FIELD], 'user')
+            self.assertEqual(cfg[r1setup.INSTALL_LAST_COLLECTION_VERSION_FIELD], '1.8.0')
+            self.assertIsNotNone(cfg[r1setup.INSTALL_LAST_AT_FIELD])
+
+    def test_normalize_host_config_backfills_install_fields(self):
+        cfg = {'ansible_host': '1.2.3.4'}
+        changed = r1setup.ConfigurationManager._normalize_host_config(cfg)
+        self.assertTrue(changed)
+        for field in r1setup.INSTALL_TRACKING_FIELDS:
+            self.assertIn(field, cfg)
+            self.assertIsNone(cfg[field])
+
+    def test_read_fetched_metadata_returns_empty_for_missing_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = r1setup.ConfigurationManager._read_fetched_metadata(
+                ['h1', 'h2'], Path(td)
+            )
+            self.assertEqual(out, {'h1': {}, 'h2': {}})
+
+    def test_read_fetched_metadata_parses_valid_json(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            (base / 'h1.json').write_text(
+                '{"image_variant": "gpu", "driver_owner": "r1setup", "image_url": "ratio1/edge_node_gpu:testnet"}'
+            )
+            out = r1setup.ConfigurationManager._read_fetched_metadata(['h1'], base)
+            self.assertEqual(out['h1']['image_variant'], 'gpu')
+            self.assertEqual(out['h1']['driver_owner'], 'r1setup')
+
+
 class TestBuildInstallExtraVars(unittest.TestCase):
     """Validates the three-mode install extra-vars builder."""
 

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -300,6 +300,155 @@ class TestDeploymentServiceVersionStamping(unittest.TestCase):
             self.assertEqual(app.run_generated_playbook.call_args_list[1].kwargs["timeout"], 180)
 
 
+class TestDeploySetupEndToEnd(unittest.TestCase):
+    """End-to-end integration tests for _deploy_setup across all three install
+    modes, plus a partial-failure case. Exercises the full happy path down to
+    the Ansible boundary, asserting that per-host install tracking + deployment
+    type + image summary hooks are wired correctly."""
+
+    def _make_app(self, base_path):
+        app = MagicMock()
+        app.check_hosts_config.return_value = True
+        app.load_configuration.return_value = True
+        app.inventory = {
+            "all": {
+                "children": {
+                    "gpu_nodes": {
+                        "hosts": {
+                            "node-a": {"ansible_host": "10.0.0.1", "ansible_user": "root"},
+                            "node-b": {"ansible_host": "10.0.0.2", "ansible_user": "root"},
+                        }
+                    }
+                }
+            }
+        }
+        app.get_mnl_app_env.return_value = "testnet"
+        app._get_node_status_info.return_value = {"status": "never_deployed"}
+        app._get_status_display_info.return_value = ("?", "yellow", "Never deployed")
+        app.get_input.return_value = "y"
+        app.config_dir = base_path
+        app.config_file = base_path / "hosts.yml"
+        app.active_config = {"deployment_status": "never_deployed"}
+        app.connection_timeout = 30
+        app.print_colored = MagicMock()
+        app.print_header = MagicMock()
+        app.wait_for_enter = MagicMock()
+        app._update_node_status = MagicMock()
+        app._display_node_status = MagicMock()
+        app._display_copy_friendly_addresses = MagicMock()
+        app.record_service_file_version = MagicMock()
+        # New per-host install-tracking delegators.
+        app.record_install_attempt = MagicMock()
+        app.record_install_success = MagicMock()
+        app.read_fetched_metadata = MagicMock(return_value={})
+        app.group_host_names_by_machine.return_value = {
+            "root@10.0.0.1:22": {"representative_host": "node-a", "host_names": ["node-a"]},
+            "root@10.0.0.2:22": {"representative_host": "node-b", "host_names": ["node-b"]},
+        }
+        app.config_manager = MagicMock()
+        app.config_manager._derive_machine_id.side_effect = (
+            lambda host_name, host_config: f"{host_config.get('ansible_user', 'root')}@{host_config['ansible_host']}:22"
+        )
+        app._parse_ansible_play_recap.return_value = {
+            "node-a": {"status": "connected"},
+            "node-b": {"status": "connected"},
+        }
+        return app
+
+    def _prep_env(self, temp_dir, select_hosts):
+        base_path = Path(temp_dir)
+        playbooks_dir = base_path / "playbooks"
+        playbooks_dir.mkdir(parents=True, exist_ok=True)
+        (playbooks_dir / "prepare_machine.yml").write_text("---\n")
+        (playbooks_dir / "apply_instance.yml").write_text("---\n")
+        app = self._make_app(base_path)
+        app.select_hosts.return_value = list(select_hosts)
+        return app
+
+    def _run_deploy(self, app, variant, manage_drivers, title="Test Install"):
+        service = r1setup.DeploymentService(app)
+        with patch.dict(os.environ, {}, clear=False):
+            with patch.object(service, "_update_deployment_metadata") as update_metadata:
+                service._deploy_setup(
+                    "site.yml",
+                    title,
+                    f"{variant} deploy",
+                    variant=variant,
+                    manage_drivers=manage_drivers,
+                )
+        return update_metadata
+
+    def test_mode_1_cpu_records_cpu_and_na_owner(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = self._prep_env(td, ["node-a"])
+            app.run_generated_playbook.side_effect = [
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+            ]
+            update_metadata = self._run_deploy(app, variant="cpu", manage_drivers=False)
+            update_metadata.assert_called_once_with("docker_only")
+            app.record_install_success.assert_called_once_with(["node-a"], "cpu", "n/a")
+            # Attempt is recorded on the same success path.
+            app.record_install_attempt.assert_any_call(["node-a"], "cpu", "n/a", "success")
+
+    def test_mode_2_gpu_managed_records_r1setup_owner(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = self._prep_env(td, ["node-a"])
+            app.run_generated_playbook.side_effect = [
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+            ]
+            update_metadata = self._run_deploy(app, variant="gpu", manage_drivers=True)
+            update_metadata.assert_called_once_with("full")
+            app.record_install_success.assert_called_once_with(["node-a"], "gpu", "r1setup")
+
+    def test_mode_3_gpu_user_records_user_owner(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = self._prep_env(td, ["node-a"])
+            app.run_generated_playbook.side_effect = [
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+                (True, "ok", ["node-a"], {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}}}}}}),
+            ]
+            update_metadata = self._run_deploy(app, variant="gpu", manage_drivers=False)
+            update_metadata.assert_called_once_with("full")
+            app.record_install_success.assert_called_once_with(["node-a"], "gpu", "user")
+
+    def test_partial_fleet_failure_records_attempt_for_failed_hosts(self):
+        with tempfile.TemporaryDirectory() as td:
+            app = self._prep_env(td, ["node-a", "node-b"])
+            # Both hosts pass machine prepare; only node-a connects during
+            # instance apply (node-b fails on that phase).
+            app.run_generated_playbook.side_effect = [
+                (True, "ok", ["node-a", "node-b"],
+                 {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}, "node-b": {}}}}}}),
+                (False, "apply-out", ["node-a", "node-b"],
+                 {"all": {"children": {"gpu_nodes": {"hosts": {"node-a": {}, "node-b": {}}}}}}),
+            ]
+            # Vary _parse_ansible_play_recap per phase: both succeed in machine
+            # prepare, only node-a in instance apply.
+            def _recap(output: str):
+                if "apply" in output:
+                    return {"node-a": {"status": "connected"}, "node-b": {"status": "failed"}}
+                return {"node-a": {"status": "connected"}, "node-b": {"status": "connected"}}
+            app._parse_ansible_play_recap.side_effect = _recap
+
+            self._run_deploy(app, variant="gpu", manage_drivers=True)
+
+            # node-a recorded as success, node-b as failed.
+            success_calls = [
+                c for c in app.record_install_attempt.call_args_list
+                if c.args[3] == "success"
+            ]
+            failed_calls = [
+                c for c in app.record_install_attempt.call_args_list
+                if c.args[3] == "failed"
+            ]
+            self.assertEqual(len(success_calls), 1, "one success batch expected")
+            self.assertEqual(success_calls[0].args[0], ["node-a"])
+            self.assertIn("node-b", failed_calls[0].args[0])
+            app.record_install_success.assert_called_once_with(["node-a"], "gpu", "r1setup")
+
+
 class TestInstallVariantSummary(unittest.TestCase):
     """Tests the per-host install-variant rollup used to replace the retired
     fleet-level last_deployment_type field."""

--- a/mnl_factory/scripts/ver.py
+++ b/mnl_factory/scripts/ver.py
@@ -3,7 +3,7 @@
 Version management for Ratio1 Multi-Node Launcher CLI
 """
 
-__VER__ = '1.7.0'
+__VER__ = '1.8.0'
 
 
 


### PR DESCRIPTION
## Summary

- **Three install modes** chosen per-host from the menu:
  - **Install CPU Nodes** — pulls `ratio1/edge_node:{env}`, skips all NVIDIA setup.
  - **Install GPU Nodes** with a sub-prompt *"Install/manage NVIDIA drivers? [Y/n]"*:
    - **Y** (Mode 2) — r1setup installs drivers + NVIDIA Container Toolkit, pulls `ratio1/edge_node_gpu:{env}`.
    - **N** (Mode 3) — r1setup runs a preflight `nvidia-smi` check and pulls `ratio1/edge_node_gpu:{env}`. **Never touches NVIDIA packages** on the host.
- **No silent fallback** on GPU failures. Failed hosts are listed for retry; surviving hosts continue to deploy. Mode 2 failures run `apt autoremove nvidia*` cleanup and then re-raise.
- **Per-host install tracking** (8 new fields in `hosts.yml`) persists last successful + last attempted variant, driver owner, timestamp, result. Surfaces in the host-selection menu as a new column: `GPU (r1) • 2026-03-12` / `CPU • 2026-02-01   GPU (user) • 2026-04-17 ✗` / `— • never`.
- **Image Summary** block after each successful deploy; mode-specific failure hints.
- **Retires** the fleet-level `last_deployment_type` field (lied on mixed fleets) in favor of a per-host variant rollup.
- **CLI 1.7.0 → 1.8.0**, **collection 1.3.35 → 1.4.0**, new `CHANGELOG.md`.

Rolled out as 10 focused commits (one per phase) on `feat/mixed-cpu-gpu-fleets` — see each commit body for scope. Plan + phased rollout are documented in [\`docs/_todos/20260418T183123_r1setup_mixed_cpu_gpu_fleets.md\`](https://github.com/toderian/project_r1_infra/blob/main/docs/_todos/20260418T183123_r1setup_mixed_cpu_gpu_fleets.md) in `project_r1_infra`.

## Test plan

- [x] **Unit + integration (automated)** — 323/323 pass: \`cd mnl_factory/scripts && python3 test_r1setup.py && python3 -m unittest discover tests\`. Added 29 new assertions covering the validation helper (3 legal / 2 illegal combos), install tracking helpers (8), column formatter (7), variant summary (5), and end-to-end \`_deploy_setup\` across all three modes + a partial-fleet failure (4).
- [x] **Ansible lint** — \`ansible-playbook --syntax-check playbooks/{site,prepare_machine,apply_instance}.yml\`.
- [x] **Real-fleet walkthrough (mixed CPU/GPU, three hosts)** — run each of the three install modes from the CLI; confirm correct image is pulled, \`--gpus all\` only present on GPU units, Image Summary renders from fetched metadata, per-host fields populate in \`hosts.yml\`.
- [ ] **Negative paths** — GPU install on no-GPU host (expect fail-fast + no CPU fallback); broken drivers on GPU host (expect cleanup rescue in Mode 2, no-touch in Mode 3); CLI hint matches the mode.
- [ ] **Inventory pin** — set \`mnl_image_variant: cpu\` as a host_var on a GPU host and verify it wins over the menu's GPU choice.
- [ ] **Custom image override** — set \`mnl_docker_image_url=myregistry.local/custom:tag\` via CUSTOMIZABLE_VARS; verify the override is pulled verbatim regardless of mode.
- [ ] **Old-inventory migration** — load a pre-1.8.0 \`hosts.yml\`; confirm the 8 new fields backfill as \`None\` and \`last_deployment_type\` is popped from the loaded fleet metadata.
- [ ] **Bare \`ansible-playbook\`** — run \`site.yml\` with no extra-vars; verify CPU image is pulled by default.
- [ ] **Galaxy build** — \`ansible-galaxy collection build mnl_factory\` produces a valid \`1.4.0\` tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)