### PR TITLE
Self-heal <collection>/hosts.yml symlink on startup

### DIFF
--- a/mnl_factory/scripts/r1setup
+++ b/mnl_factory/scripts/r1setup
@@ -14085,8 +14085,67 @@ PY"""
             self.print_debug(f"Failed to restore active config: {config_name}")
         return restored
 
+    def _ensure_hosts_yml_linked(self) -> bool:
+        """Idempotently reconcile the <collection>/hosts.yml symlink with the
+        active config stored in active_config.json + configs/<name>.yml.
+
+        Returns True if the symlink now points at the active config's YAML
+        (either because it already did, or because we just linked it).
+        Returns False if there's nothing to link (no active config name, or
+        the backing YAML is missing on disk).
+
+        This is the single reconciliation point between the two sources of
+        truth ("what's active" in active_config.json vs "what Ansible reads"
+        via <collection>/hosts.yml). Call it anywhere you'd otherwise worry
+        that check_hosts_config() might be stale.
+        """
+        try:
+            self._load_active_config()
+        except Exception as exc:
+            self.print_debug(f"_ensure_hosts_yml_linked: could not load active_config: {exc}")
+            return False
+
+        config_name = self.active_config.get('config_name')
+        if not config_name:
+            return False
+
+        config_path = self.configs_dir / f"{config_name}.yml"
+        if not config_path.exists():
+            self.print_debug(
+                f"_ensure_hosts_yml_linked: configs/{config_name}.yml missing, nothing to link"
+            )
+            return False
+
+        # Already pointing at the right place? Fast path, no I/O churn.
+        if self.config_file.is_symlink():
+            try:
+                if self.config_file.resolve() == config_path.resolve():
+                    return True
+            except (OSError, RuntimeError):
+                pass
+
+        # Otherwise, heal. _update_hosts_symlink is already idempotent and
+        # handles the "file exists, not a symlink" edge case.
+        try:
+            self.config_manager._update_hosts_symlink(config_path)
+            self.print_debug(f"_ensure_hosts_yml_linked: linked hosts.yml -> {config_path}")
+            return True
+        except Exception as exc:
+            self.print_debug(f"_ensure_hosts_yml_linked: failed to link {config_path}: {exc}")
+            return False
+
     def ensure_active_configuration(self) -> bool:
         """Ensure there's an active configuration before proceeding to main menu"""
+        # Self-heal the <collection>/hosts.yml symlink from the active
+        # configuration before any gating checks. Two sources of truth
+        # exist — active_config.json + configs/<name>.{yml,json} (user data)
+        # vs <collection>/hosts.yml (Ansible runtime pointer). They can
+        # diverge (fresh dev HOME, deleted symlink, switched checkouts),
+        # and without this heal, has_active_config_shell() lets users into
+        # the main menu while every check_hosts_config()-gated action fails
+        # with "No nodes configured!". Idempotent and cheap.
+        self._ensure_hosts_yml_linked()
+
         # Check if we have a valid active configuration (hosts OR zero-host shell)
         if self.has_active_config_shell():
             return True

--- a/mnl_factory/scripts/tests/test_r1setup_core.py
+++ b/mnl_factory/scripts/tests/test_r1setup_core.py
@@ -672,6 +672,96 @@ class TestInstallTrackingHelpers(unittest.TestCase):
             self.assertEqual(out['h1']['driver_owner'], 'r1setup')
 
 
+class TestEnsureHostsYmlLinked(unittest.TestCase):
+    """Regression: when active_config.json points at a config and the
+    corresponding configs/<name>.yml exists but <collection>/hosts.yml is
+    missing (fresh dev HOME, deleted symlink, switched checkouts), startup
+    must self-heal so check_hosts_config()-gated actions don't fail with
+    'No nodes configured!'."""
+
+    def _prep_app(self, td: Path, active_config_name: str):
+        """Assemble an R1Setup instance with a real on-disk configs layout
+        but mocked-out methods where touching them would be noisy."""
+        configs_dir = td / "configs"
+        configs_dir.mkdir()
+        collection_dir = td / "collection"
+        collection_dir.mkdir()
+        # Synthesize a minimal valid inventory for the active config.
+        config_yaml = configs_dir / f"{active_config_name}.yml"
+        config_yaml.write_text(
+            "all:\n  children:\n    gpu_nodes:\n      hosts:\n        edge_node:\n          ansible_host: 1.2.3.4\n"
+        )
+        active_config_file = td / "active_config.json"
+        active_config_file.write_text(
+            '{"config_name": "' + active_config_name + '", "deployment_status": "deployed"}'
+        )
+
+        app = r1setup.R1Setup.__new__(r1setup.R1Setup)
+        app.configs_dir = configs_dir
+        app.config_dir = collection_dir
+        app.config_file = collection_dir / "hosts.yml"
+        app.active_config_file = active_config_file
+        app.print_colored = MagicMock()
+        app.print_debug = MagicMock()
+        # Init config_manager before touching active_config (the property
+        # setter on R1Setup forwards to config_manager.active_config).
+        cm = r1setup.ConfigurationManager.__new__(r1setup.ConfigurationManager)
+        cm.app = app
+        cm.active_config = {}
+        app.config_manager = cm
+        # Wire just enough of _load_active_config for the heal path.
+        def _load_active_config():
+            import json
+            with open(active_config_file) as fh:
+                cm.active_config.update(json.load(fh))
+        app._load_active_config = _load_active_config
+        return app, config_yaml
+
+    def test_heal_creates_symlink_when_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            app, config_yaml = self._prep_app(Path(td), "my-fleet")
+            self.assertFalse(app.config_file.exists())
+            healed = app._ensure_hosts_yml_linked()
+            self.assertTrue(healed)
+            self.assertTrue(app.config_file.is_symlink())
+            self.assertEqual(app.config_file.resolve(), config_yaml.resolve())
+
+    def test_heal_is_idempotent_when_already_linked(self):
+        with tempfile.TemporaryDirectory() as td:
+            app, config_yaml = self._prep_app(Path(td), "my-fleet")
+            app._ensure_hosts_yml_linked()
+            # Running again should short-circuit and not re-create the symlink.
+            before_mtime = app.config_file.lstat().st_mtime_ns
+            result = app._ensure_hosts_yml_linked()
+            self.assertTrue(result)
+            self.assertEqual(app.config_file.lstat().st_mtime_ns, before_mtime)
+
+    def test_heal_skips_when_no_active_config_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            app, _ = self._prep_app(Path(td), "my-fleet")
+            # Clear the name to simulate a truly-unconfigured state.
+            app.active_config_file.write_text('{}')
+            app.config_manager.active_config.clear()
+            self.assertFalse(app._ensure_hosts_yml_linked())
+            self.assertFalse(app.config_file.exists())
+
+    def test_heal_skips_when_configs_yaml_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            app, config_yaml = self._prep_app(Path(td), "my-fleet")
+            config_yaml.unlink()  # stale active_config pointing at missing YAML
+            self.assertFalse(app._ensure_hosts_yml_linked())
+            self.assertFalse(app.config_file.exists())
+
+    def test_heal_replaces_symlink_pointing_at_wrong_config(self):
+        with tempfile.TemporaryDirectory() as td:
+            app, active_yaml = self._prep_app(Path(td), "my-fleet")
+            stale = app.configs_dir / "other-fleet.yml"
+            stale.write_text("all:\n  children:\n    gpu_nodes:\n      hosts: {}\n")
+            app.config_file.symlink_to(stale)
+            app._ensure_hosts_yml_linked()
+            self.assertEqual(app.config_file.resolve(), active_yaml.resolve())
+
+
 class TestAutoUpdateConstants(unittest.TestCase):
     """Auto-update URL invariants. A broken primary URL is masked by the
     raw-main fallback, but leaves every upgrade paying a wasted 404 and


### PR DESCRIPTION
## Summary

Fixes a false-positive \"No nodes configured!\" error that hit when running the 1.8.0 CLI against an existing config — e.g., via \`scripts/run_r1setup_repo_local.sh --use-real-configs\` on a fresh dev HOME.

### Root cause

r1setup maintains two sources of truth about the active fleet:

1. **Data model** — \`active_config.json\` + \`configs/<name>.{yml,json}\` (what the user configured).
2. **Runtime pointer** — \`<collection>/hosts.yml\` symlink (what Ansible reads).

Normal deploy/save flows keep them in sync via \`_update_hosts_symlink()\`. But whenever the runtime pointer is lost without a corresponding data-model change (fresh dev HOME, deleted symlink, checkout switch, manual cleanup), \`has_active_config_shell()\` still returns True — it only inspects the data model. \`ensure_active_configuration()\` lets the user into the main menu, and every subsequent \`check_hosts_config()\`-gated action (Node Status, Deploy, Operations…) silently fails.

### Fix

New \`R1Setup._ensure_hosts_yml_linked()\` is the single reconciliation point between the two sources of truth. Called unconditionally at the top of \`ensure_active_configuration()\` — heals before any gating check.

Semantics:
- If \`active_config\` has a \`config_name\` AND \`configs/<name>.yml\` exists → point \`<collection>/hosts.yml\` at it (creating, or replacing a stale target).
- Either prerequisite missing → skip silently; normal \"Configuration Required\" flow runs.
- Already correctly linked → no-op, no I/O churn.

### Covers

- Fresh \`./scripts/run_r1setup_repo_local.sh\` dev HOME against real configs.
- \`<collection>/hosts.yml\` accidentally deleted.
- \`<collection>\` dir rebuilt from the template without \`hosts.yml\`.
- Config switched on disk without going through the normal save path.

## Test plan

- [x] New unit-test class \`TestEnsureHostsYmlLinked\` — 5 assertions covering: missing-link create, idempotent re-run, no-op when data model is incomplete (missing name, missing YAML), replace-stale-target. Full suite green (340/340).
- [ ] Manual: \`bash scripts/run_r1setup_repo_local.sh --reset --use-real-configs\`, pick \"Node Status & Info\" — should load without the false-positive error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)